### PR TITLE
Fix clean order in AnyFixture.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.1.1
+
+- AnyFixture: clean tables in reverse order to not fail when foreign keys exist. ([@marshall-lee][])
+
 ## 0.1.0
 
 - Initial version. ([@palkan][])

--- a/lib/test_prof/any_fixture.rb
+++ b/lib/test_prof/any_fixture.rb
@@ -34,7 +34,7 @@ module TestProf
 
       # Clean all affected tables (but do not reset cache)
       def clean
-        tables_cache.keys.each do |table|
+        tables_cache.keys.reverse_each do |table|
           ActiveRecord::Base.connection.execute %(
             DELETE FROM #{table}
           )

--- a/lib/test_prof/version.rb
+++ b/lib/test_prof/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TestProf
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/integrations/fixtures/rspec/any_fixture_fixture.rb
+++ b/spec/integrations/fixtures/rspec/any_fixture_fixture.rb
@@ -30,6 +30,7 @@ end
 
 describe "Post", :user do
   let(:post) { FactoryGirl.create(:post, user: user) }
+  after { post.destroy }
 
   it "creates post with the same user" do
     expect { post }.not_to change(User, :count)

--- a/spec/support/ar_models.rb
+++ b/spec/support/ar_models.rb
@@ -13,6 +13,7 @@ ActiveRecord::Schema.define do
   create_table :posts do |t|
     t.text :text
     t.integer :user_id
+    t.foreign_key :users
   end
 end
 


### PR DESCRIPTION
Cleaning tables in direct order fails if foreign keys exist.