### PR TITLE
Combine RSpecStamp with EventProf and RSpecDissect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 Features:
 
+- [#17](https://github.com/palkan/test-prof/pull/17) Combine RSpecStamp with EventProf and RSpecDissect. ([@palkan][])
+
+It is possible now to automatically mark _slow_ examples and groups with custom tags. For example:
+
+```sh
+EVENT_PROF="sql.active_record" EVENT_PROF_STAMP="slow:sql" rspec ...
+```
+
+After running the command above the top 5 slowest example groups would be marked with `slow: :sql` tag.
+
 - [#14](https://github.com/palkan/test-prof/pull/14) RSpecDissect profiler. ([@palkan][])
 
 RSpecDissect tracks how much time do you spend in `before` hooks 

--- a/guides/event_prof.md
+++ b/guides/event_prof.md
@@ -66,6 +66,16 @@ EVENT_PROF_RANK=count EVENT_PROF='instantiation.active_record' be rspec
 
 See [event_prof.rb](https://github.com/palkan/test-prof/tree/master/lib/test_prof/event_prof.rb) for all available configuration options and their usage.
 
+## Using with RSpecStamp
+
+EventProf can be used with [RSpec Stamp](https://github.com/palkan/test-prof/tree/master/guides/rspec_stamp.md) to automatically mark _slow_ examples with custom tags. For example:
+
+```sh
+EVENT_PROF="sql.active_record" EVENT_PROF_STAMP="slow:sql" rspec ...
+```
+
+After running the command above the slowest example groups (and examples if configured) would be marked with the `slow: :sql` tag.
+
 ## Custom Instrumentation
 
 To use EventProf with your instrumentation engine just complete the two following steps:

--- a/guides/rspec_dissect.md
+++ b/guides/rspec_dissect.md
@@ -47,3 +47,12 @@ You can also specify the number of top slow groups through `RD_TOP` variable:
 RD=1 RD_TOP=10 rspec ...
 ```
 
+## Using with RSpecStamp
+
+RSpecDissect can be used with [RSpec Stamp](https://github.com/palkan/test-prof/tree/master/guides/rspec_stamp.md) to automatically mark _slow_ examples with custom tags. For example:
+
+```sh
+RD=1 RD_STAMP="slow" rspec ...
+```
+
+After running the command above the slowest example groups would be marked with the `:slow` tag.

--- a/lib/test_prof/event_prof.rb
+++ b/lib/test_prof/event_prof.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "test_prof/rspec_stamp"
 require "test_prof/event_prof/instrumentations/active_support"
 require "test_prof/utils/sized_ordered_set"
 
@@ -39,6 +40,13 @@ module TestProf
         @top_count = (ENV['EVENT_PROF_TOP'] || 5).to_i
         @per_example = ENV['EVENT_PROF_EXAMPLES'] == '1'
         @rank_by = (ENV['EVENT_PROF_RANK'] || :time).to_sym
+        @stamp = ENV['EVENT_PROF_STAMP']
+
+        RSpecStamp.config.tags = @stamp if stamp?
+      end
+
+      def stamp?
+        !@stamp.nil?
       end
 
       def per_example?

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -22,7 +22,7 @@ module TestProf
     # Use uniq prefix for instance variables to avoid collisions
     # We want to use the power of Ruby's unicode support)
     # And we love cats!)
-    PREFIX = "@😸".freeze
+    PREFIX = RUBY_ENGINE == 'jruby' ? "@__jruby_is_not_cat_friendly__".freeze : "@😸".freeze
 
     def let_it_be(identifier, **options, &block)
       initializer = proc do

--- a/lib/test_prof/rspec_dissect.rb
+++ b/lib/test_prof/rspec_dissect.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "test_prof/rspec_stamp"
 require "test_prof/logging"
 
 module TestProf
@@ -36,6 +37,13 @@ module TestProf
 
       def initialize
         @top_count = (ENV['RD_TOP'] || 5).to_i
+        @stamp = ENV['RD_STAMP']
+
+        RSpecStamp.config.tags = @stamp if stamp?
+      end
+
+      def stamp?
+        !@stamp.nil?
       end
     end
 

--- a/lib/test_prof/rspec_dissect/rspec.rb
+++ b/lib/test_prof/rspec_dissect/rspec.rb
@@ -96,6 +96,39 @@ module TestProf
         end
 
         log :info, msgs.join
+
+        stamp! if RSpecDissect.config.stamp?
+      end
+
+      def stamp!
+        stamper = RSpecStamp::Stamper.new
+
+        examples = Hash.new { |h, k| h[k] = [] }
+
+        (@before_results.to_a + @memo_results.to_a)
+          .map { |obj| obj[:loc] }.each do |location|
+          file, line = location.split(":")
+          examples[file] << line.to_i
+        end
+
+        examples.each do |file, lines|
+          stamper.stamp_file(file, lines.uniq)
+        end
+
+        msgs = []
+
+        msgs <<
+          <<-MSG.strip_heredoc
+            RSpec Stamp results
+
+            Total patches: #{stamper.total}
+            Total files: #{examples.keys.size}
+
+            Failed patches: #{stamper.failed}
+            Ignored files: #{stamper.ignored}
+          MSG
+
+        log :info, msgs.join
       end
 
       private

--- a/lib/test_prof/rspec_stamp/rspec.rb
+++ b/lib/test_prof/rspec_stamp/rspec.rb
@@ -30,8 +30,10 @@ module TestProf
       end
 
       def stamp!
+        stamper = Stamper.new
+
         @examples.each do |file, lines|
-          stamp_file(file, lines.uniq)
+          stamper.stamp_file(file, lines.uniq)
         end
 
         msgs = []
@@ -40,43 +42,14 @@ module TestProf
           <<-MSG.strip_heredoc
             RSpec Stamp results
 
-            Total patches: #{@total}
+            Total patches: #{stamper.total}
             Total files: #{@examples.keys.size}
 
-            Failed patches: #{@failed}
-            Ignored files: #{@ignored}
+            Failed patches: #{stamper.failed}
+            Ignored files: #{stamper.ignored}
           MSG
 
         log :info, msgs.join
-      end
-
-      private
-
-      def stamp_file(file, lines)
-        @total += lines.size
-        return if ignored?(file)
-
-        log :info, "(dry-run) Patching #{file}" if dry_run?
-
-        code = File.readlines(file)
-
-        @failed += RSpecStamp.apply_tags(code, lines, RSpecStamp.config.tags)
-
-        File.write(file, code.join) unless dry_run?
-      end
-
-      def ignored?(file)
-        ignored = RSpecStamp.config.ignore_files.find do |pattern|
-          file =~ pattern
-        end
-
-        return unless ignored
-        log :warn, "Ignore stamping file: #{file}"
-        @ignored += 1
-      end
-
-      def dry_run?
-        RSpecStamp.config.dry_run?
       end
     end
   end

--- a/lib/test_prof/utils/sized_ordered_set.rb
+++ b/lib/test_prof/utils/sized_ordered_set.rb
@@ -54,7 +54,7 @@ module TestProf
       end
 
       def to_a
-        data
+        data.dup
       end
 
       private

--- a/spec/integrations/event_prof_spec.rb
+++ b/spec/integrations/event_prof_spec.rb
@@ -52,6 +52,79 @@ describe "EventProf" do
     )
   end
 
+  context "with RStamp" do
+    before do
+      FileUtils.cp(
+        File.expand_path("../../integrations/fixtures/rspec/event_prof_stamp_fixture_tmpl.rb", __FILE__),
+        File.expand_path("../../integrations/fixtures/rspec/event_prof_stamp_fixture.rb", __FILE__)
+      )
+    end
+
+    after do
+      FileUtils.rm(
+        File.expand_path("../../integrations/fixtures/rspec/event_prof_stamp_fixture.rb", __FILE__)
+      )
+    end
+
+    specify "it works with groups", :aggregate_failures do
+      output = run_rspec(
+        'event_prof_stamp',
+        env: { 'EVENT_PROF' => 'test.event', 'EVENT_PROF_STAMP' => 'slow', 'EVENT_PROF_TOP' => '1' }
+      )
+
+      expect(output).to include("5 examples, 0 failures")
+
+      expect(output).to include("EventProf results for test.event")
+      expect(output).to include("Total events: 7")
+
+      expect(output).to include("Top 1 slowest suites (by time):")
+
+      expect(output).to include("RSpec Stamp results")
+      expect(output).to include("Total patches: 1")
+      expect(output).to include("Total files: 1")
+      expect(output).to include("Failed patches: 0")
+      expect(output).to include("Ignored files: 0")
+
+      output2 = run_rspec(
+        'event_prof_stamp',
+        env: { 'SPEC_OPTS' => '--tag slow' }
+      )
+
+      expect(output2).to include("3 examples, 0 failures")
+    end
+
+    specify "it works with groups and examples", :aggregate_failures do
+      output = run_rspec(
+        'event_prof_stamp',
+        env: {
+          'EVENT_PROF' => 'test.event', 'EVENT_PROF_STAMP' => 'slow:test_event',
+          'EVENT_PROF_TOP' => '1', 'EVENT_PROF_EXAMPLES' => '1'
+        }
+      )
+
+      expect(output).to include("5 examples, 0 failures")
+
+      expect(output).to include("EventProf results for test.event")
+      expect(output).to include("Total events: 7")
+
+      expect(output).to include("Top 1 slowest suites (by time):")
+      expect(output).to include("Top 1 slowest tests (by time):")
+
+      expect(output).to include("RSpec Stamp results")
+      expect(output).to include("Total patches: 2")
+      expect(output).to include("Total files: 1")
+      expect(output).to include("Failed patches: 0")
+      expect(output).to include("Ignored files: 0")
+
+      output2 = run_rspec(
+        'event_prof_stamp',
+        env: { 'SPEC_OPTS' => '--tag slow:test_event' }
+      )
+
+      expect(output2).to include("4 examples, 0 failures")
+    end
+  end
+
   context "CustomEvents" do
     it "works with factory.create" do
       output = run_rspec(

--- a/spec/integrations/fixtures/rspec/any_fixture_fixture.rb
+++ b/spec/integrations/fixtures/rspec/any_fixture_fixture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require_relative "../../../support/ar_models"
 require_relative "../../../support/transactional_context"
 require "test_prof/recipes/rspec/any_fixture"

--- a/spec/integrations/fixtures/rspec/before_all_fixture.rb
+++ b/spec/integrations/fixtures/rspec/before_all_fixture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require_relative "../../../support/ar_models"
 require_relative "../../../support/transactional_context"
 require "test_prof/recipes/rspec/before_all"

--- a/spec/integrations/fixtures/rspec/event_prof_factory_create_fixture.rb
+++ b/spec/integrations/fixtures/rspec/event_prof_factory_create_fixture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require_relative "../../../support/ar_models"
 require "test-prof"
 

--- a/spec/integrations/fixtures/rspec/event_prof_fixture.rb
+++ b/spec/integrations/fixtures/rspec/event_prof_fixture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require "active_support"
 require "test-prof"
 

--- a/spec/integrations/fixtures/rspec/event_prof_sidekiq_fixture.rb
+++ b/spec/integrations/fixtures/rspec/event_prof_sidekiq_fixture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require "active_support"
 require "sidekiq/testing"
 

--- a/spec/integrations/fixtures/rspec/event_prof_stamp_fixture_tmpl.rb
+++ b/spec/integrations/fixtures/rspec/event_prof_stamp_fixture_tmpl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require "active_support"
 require "test-prof"
 

--- a/spec/integrations/fixtures/rspec/event_prof_stamp_fixture_tmpl.rb
+++ b/spec/integrations/fixtures/rspec/event_prof_stamp_fixture_tmpl.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+require "active_support"
+require "test-prof"
+
+module Instrumenter
+  def self.notify(_event, time)
+    ActiveSupport::Notifications.publish(
+      'test.event',
+      0,
+      time
+    )
+  end
+end
+
+describe "Something" do
+  it "invokes once" do
+    Instrumenter.notify 'test.event', 40.1
+    expect(true).to eq true
+  end
+
+  it "invokes twice" do
+    Instrumenter.notify 'test.event', 140
+    Instrumenter.notify 'test.event', 240
+    expect(true).to eq true
+  end
+
+  it "invokes many times" do
+    Instrumenter.notify 'test.event', 400
+    Instrumenter.notify 'test.event', 42
+    Instrumenter.notify 'test.event', 340
+    expect(true).to eq true
+  end
+end
+
+describe "Another something" do
+  it "do nothing" do
+    expect(true).to eq true
+  end
+
+  it "do very long" do
+    Instrumenter.notify 'test.event', 1000
+    expect(true).to eq true
+  end
+end

--- a/spec/integrations/fixtures/rspec/factory_default_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_default_fixture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require_relative "../../../support/ar_models"
 require_relative "../../../support/transactional_context"
 require "test_prof/recipes/rspec/factory_default"

--- a/spec/integrations/fixtures/rspec/factory_doctor_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_doctor_fixture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require_relative "../../../support/ar_models"
 require "test-prof"
 

--- a/spec/integrations/fixtures/rspec/factory_prof_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_prof_fixture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require_relative "../../../support/ar_models"
 require "test-prof"
 

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require_relative "../../../support/ar_models"
 require_relative "../../../support/transactional_context"
 require "test_prof/recipes/rspec/let_it_be"

--- a/spec/integrations/fixtures/rspec/rspec_dissect_stamp_fixture_tmpl.rb
+++ b/spec/integrations/fixtures/rspec/rspec_dissect_stamp_fixture_tmpl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 
 require "test-prof"
 
@@ -19,7 +19,7 @@ class Work
   end
 end
 
-describe "Subject + Before" do
+describe 'Subject + Before' do
   subject(:work) { Work.new }
 
   specify do
@@ -27,6 +27,7 @@ describe "Subject + Before" do
   end
 
   it "does nothing" do
+    work
     expect(true).to eq true
   end
 
@@ -39,15 +40,15 @@ describe "Subject + Before" do
   end
 end
 
-describe "Only let" do
+describe 'Only let' do
   let(:work) { Work.new }
-  let(:more_work) { Work.new(1) }
+  let(:work2) { Work.new }
 
   it "does nothing" do
     expect(true).to eq true
   end
 
   it "takes very long" do
-    expect(work).not_to eq more_work
+    expect(work).not_to eq work2
   end
 end

--- a/spec/integrations/fixtures/rspec/rspec_stamp_fixture_tmpl.rb
+++ b/spec/integrations/fixtures/rspec/rspec_stamp_fixture_tmpl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require "active_support"
 require "test-prof"
 

--- a/spec/integrations/fixtures/rspec/sample_fixture.rb
+++ b/spec/integrations/fixtures/rspec/sample_fixture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require "test_prof/recipes/rspec/sample"
 
 describe "Something" do

--- a/spec/integrations/fixtures/rspec/tag_prof_fixture.rb
+++ b/spec/integrations/fixtures/rspec/tag_prof_fixture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require "test-prof"
 
 describe "Something" do

--- a/spec/integrations/rspec_dissect_spec.rb
+++ b/spec/integrations/rspec_dissect_spec.rb
@@ -35,4 +35,46 @@ describe "RSpecDissect" do
       "Only let (./rspec_dissect_fixture.rb:42) – "
     )
   end
+
+  context "with RStamp" do
+    before do
+      FileUtils.cp(
+        File.expand_path("../../integrations/fixtures/rspec/rspec_dissect_stamp_fixture_tmpl.rb", __FILE__),
+        File.expand_path("../../integrations/fixtures/rspec/rspec_dissect_stamp_fixture.rb", __FILE__)
+      )
+    end
+
+    after do
+      FileUtils.rm(
+        File.expand_path("../../integrations/fixtures/rspec/rspec_dissect_stamp_fixture.rb", __FILE__)
+      )
+    end
+
+    specify "it works", :aggregate_failures do
+      output = run_rspec(
+        'rspec_dissect_stamp',
+        env: { 'RD' => '1', 'RD_STAMP' => 'slow', 'RD_TOP' => '1' }
+      )
+
+      expect(output).to include("5 examples, 0 failures")
+
+      expect(output).to include_lines(
+        "Top 1 slowest suites (by `before(:each)` time):",
+        "Subject + Before (./rspec_dissect_stamp_fixture.rb:22) – "
+      )
+
+      expect(output).to include("RSpec Stamp results")
+      expect(output).to include("Total patches: 1")
+      expect(output).to include("Total files: 1")
+      expect(output).to include("Failed patches: 0")
+      expect(output).to include("Ignored files: 0")
+
+      output2 = run_rspec(
+        'rspec_dissect_stamp',
+        env: { 'SPEC_OPTS' => '--tag slow' }
+      )
+
+      expect(output2).to include("3 examples, 0 failures")
+    end
+  end
 end


### PR DESCRIPTION
Make it possible to automatically mark _slow_ examples and groups with custom tags. For example:

```sh
EVENT_PROF="sql.active_record" EVENT_PROF_STAMP="slow:sql" rspec ...
```

After running the command above the top 5 slowest example groups would be marked with `slow: :sql` tag.
