### PR TITLE
Add support for fresh new Rubocop 0.50

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ AllCops:
 Rails:
   Enabled: false
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
 
 Style/TrivialAccessors:
@@ -28,7 +28,7 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*.rb'
 
-Style/StringLiterals: 
+Style/StringLiterals:
   Enabled: false
 
 Style/RegexpLiteral:

--- a/lib/test_prof/event_prof.rb
+++ b/lib/test_prof/event_prof.rb
@@ -76,7 +76,7 @@ module TestProf
     class Profiler # :nodoc:
       include TestProf::Logging
 
-      attr_reader :event, :top_count, :rank_by, :total_count, :total_time
+      attr_reader :event, :total_count, :total_time
 
       def initialize(event:, instrumenter:)
         @event = event

--- a/lib/test_prof/rspec_stamp.rb
+++ b/lib/test_prof/rspec_stamp.rb
@@ -10,7 +10,8 @@ module TestProf
 
     # RSpecStamp configuration
     class Configuration
-      attr_accessor :ignore_files, :dry_run, :tags
+      attr_reader :tags
+      attr_accessor :ignore_files, :dry_run
 
       def initialize
         @ignore_files = [%r{spec/support}]
@@ -88,7 +89,7 @@ module TestProf
 
         tags.each do |t|
           if t.is_a?(Hash)
-            t.keys.each do |k|
+            t.each_key do |k|
               parsed.remove_tag(k)
               parsed.add_htag(k, t[k])
             end

--- a/spec/test_prof/cops/rspec/aggregate_failures_spec.rb
+++ b/spec/test_prof/cops/rspec/aggregate_failures_spec.rb
@@ -7,84 +7,84 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'rejects two one-liners in a row' do
-    inspect_source(cop, ['context "request" do',
-                         '  it { is_expected.to be_success }',
-                         '  it { expect(response.body).to eq "OK" }',
-                         'end'])
+    inspect_source(['context "request" do',
+                    '  it { is_expected.to be_success }',
+                    '  it { expect(response.body).to eq "OK" }',
+                    'end'])
+
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages.first).to eq('Use :aggregate_failures instead of several one-liners.')
   end
 
   it 'rejects two one-liners when blank lines and non-example blocks' do
-    inspect_source(cop, ['context "request" do',
-                         '  let(:user) { create(:user) } ',
-                         '  before { get "/" }',
-                         '',
-                         '  it { is_expected.to be_success }',
-                         '  ',
-                         '      ',
-                         '  it { expect(response.body).to eq "OK" }',
-                         'end'])
+    inspect_source(['context "request" do',
+                    '  let(:user) { create(:user) } ',
+                    '  before { get "/" }',
+                    '',
+                    '  it { is_expected.to be_success }',
+                    '  ',
+                    '      ',
+                    '  it { expect(response.body).to eq "OK" }',
+                    'end'])
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages.first).to eq('Use :aggregate_failures instead of several one-liners.')
   end
 
   it 'rejects one-liners with nested context' do
-    inspect_source(cop, ['context "request" do',
-                         '  it { is_expected.to be_success }',
-                         '  it "works" do',
-                         '    expect(subject).to be_ok',
-                         '  end',
-                         '  it { expect(response.body).to eq "OK" }',
-                         '',
-                         '  context "sub-request" do',
-                         '    let(:params) { "?q=1" }',
-                         '    it { is_expected.to be_valid }',
-                         '  end',
-                         'end'])
+    inspect_source(['context "request" do',
+                    '  it { is_expected.to be_success }',
+                    '  it "works" do',
+                    '    expect(subject).to be_ok',
+                    '  end',
+                    '  it { expect(response.body).to eq "OK" }',
+                    '',
+                    '  context "sub-request" do',
+                    '    let(:params) { "?q=1" }',
+                    '    it { is_expected.to be_valid }',
+                    '  end',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts single one-liner' do
-    inspect_source(cop, ['context "request" do',
-                         '  it { is_expected.to be_success }',
-                         'end'])
+    inspect_source(['context "request" do',
+                    '  it { is_expected.to be_success }',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts one-liners separated by multiliners' do
-    inspect_source(cop, ['context "request" do',
-                         '  it { is_expected.to be_success }',
-                         '  it "works" do',
-                         '    expect(subject).to be_ok',
-                         '  end',
-                         '  it { expect(response.body).to eq "OK" }',
-                         'end'])
+    inspect_source(['context "request" do',
+                    '  it { is_expected.to be_success }',
+                    '  it "works" do',
+                    '    expect(subject).to be_ok',
+                    '  end',
+                    '  it { expect(response.body).to eq "OK" }',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'handles edge cases' do
-    inspect_source(cop, ['context "request" do',
-                         '  include_examples "edges"',
-                         '  xdescribe "POST #create" do',
-                         '  end',
-                         '',
-                         '  pending {}',
-                         'end'])
+    inspect_source(['context "request" do',
+                    '  include_examples "edges"',
+                    '  xdescribe "POST #create" do',
+                    '  end',
+                    '',
+                    '  pending {}',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'handles edge cases 2' do
-    inspect_source(cop, ['context "request" do',
-                         '  include_examples "edges"',
-                         'end'])
+    inspect_source(['context "request" do',
+                    '  include_examples "edges"',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   describe "#autocorrect" do
     it "corrects two one-liners" do
       new_source = autocorrect_source(
-        cop,
         ['context "request" do',
          '  it { is_expected.to be_success }',
          '  it { expect(response.body).to eq "OK" }',
@@ -103,7 +103,6 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
 
     it 'corrects indented one-liners when blank lines and non-example blocks' do
       new_source = autocorrect_source(
-        cop,
         ['describe "GET #index" do',
          '  context "request" do',
          '    let(:user) { create(:user) } ',
@@ -133,7 +132,6 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
 
     it "corrects several groups" do
       new_source = autocorrect_source(
-        cop,
         [
           'describe "GET #index" do',
           '  context "request" do',

--- a/test-prof.gemspec
+++ b/test-prof.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "minitest", "~> 5.9"
-  spec.add_development_dependency "rubocop", "~> 0.49"
+  spec.add_development_dependency "rubocop", "~> 0.50"
 end


### PR DESCRIPTION
There are some changes in RSpec helpers, group names and new cops. Offences are already fixed too.