### PR TITLE
Fabrication integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Master branch
+
+### Features:
+
+- [#30](https://github.com/palkan/test-prof/pull/30) Fabrication support for FactoryProf. ([@Shkrt][])
+
+FactoryProf now also accounts objects created by Fabrication gem (in addition to FactoryGirl)
+
 ## 0.3.0
 
 ### Features:
@@ -20,7 +28,7 @@ After running the command above the top 5 slowest example groups would be marked
 
 - [#14](https://github.com/palkan/test-prof/pull/14) RSpecDissect profiler. ([@palkan][])
 
-RSpecDissect tracks how much time do you spend in `before` hooks 
+RSpecDissect tracks how much time do you spend in `before` hooks
 and memoization helpers (i.e. `let`) in your tests.
 
 - [#13](https://github.com/palkan/test-prof/pull/13) RSpec `let_it_be` method. ([@palkan][])
@@ -89,3 +97,4 @@ Ensure output dir exists in `#artifact_path` method.
 [@palkan]: https://github.com/palkan
 [@marshall-lee]: https://github.com/marshall-lee
 [@danielwestendorf]: https://github.com/danielwestendorf
+[@Shkrt]: https://github.com/Shkrt

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "sqlite3"
 gem "activerecord", "~> 5.0"
 
 gem "factory_girl", "~> 4.8.0"
+gem "fabrication"
 
 gem "sidekiq", "~> 4.0"
 gem "timecop", "~> 0.9.1"

--- a/README.md
+++ b/README.md
@@ -114,8 +114,6 @@ Or TODO list:
 
 - Better Minitest integration (PRs welcome!)
 
-- Other data generation library support (e.g [Fabricator](http://fabricationgem.org/)). _Does anyone use something except from FactoryGirl?_
-
 - Improve FactoryDoctor
 
 - Add more Rubocop cops (e.g. `CreateListLimit`)

--- a/gemfiles/activerecord42.gemfile
+++ b/gemfiles/activerecord42.gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'activerecord', '~> 4.2'
 gem "factory_girl", "~> 4.8.0"
+gem "fabrication"
 gem "sqlite3"
 gem "sidekiq", "~> 3.0"
 gem "timecop", "~> 0.9.1"

--- a/gemfiles/jruby.gemfile
+++ b/gemfiles/jruby.gemfile
@@ -7,6 +7,7 @@ gem "activerecord-jdbcsqlite3-adapter"
 gem "activerecord", "~> 4.2"
 
 gem "factory_girl", "~> 4.8.0"
+gem "fabrication"
 
 gem "sidekiq", "~> 4.0"
 gem "timecop", "~> 0.9.1"

--- a/gemfiles/railsmaster.gemfile
+++ b/gemfiles/railsmaster.gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'arel', github: 'rails/arel'
 gem 'rails', github: 'rails/rails'
+gem "fabrication"
 gem "factory_girl", "~> 4.8.0"
 gem "sqlite3"
 gem "sidekiq", "~> 4.0"

--- a/guides/factory_prof.md
+++ b/guides/factory_prof.md
@@ -16,11 +16,12 @@ Example output:
 
 It shows both the total number of the factory runs and the number of _top-level_ runs, i.e. not during another factory invocation (e.g. when using associations.)
 
-**NOTE**: FactoryProf only tracks the usage of `create` strategy.
+**NOTE**: FactoryProf only tracks the database-persisted factories. In case of FactoryFirl these are the factories
+provided by using `create` strategy. In case of Fabrication - objects that created using `create` method.
 
 ## Instructions
 
-FactoryProf can only be used with FactoryGirl.
+FactoryProf can be used with FactoryGirl or Fabrication - application can be bundled with both gems at the same time.
 
 To activate FactoryProf use `FPROF` environment variable:
 

--- a/lib/test_prof/factory_prof.rb
+++ b/lib/test_prof/factory_prof.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "test_prof/factory_prof/factory_girl_patch"
-require "test_prof/factory_prof/fabrication_patch"
 require "test_prof/factory_prof/printers/simple"
 require "test_prof/factory_prof/printers/flamegraph"
 require "test_prof/factory_prof/factory_builders/factory_girl"
@@ -11,7 +9,6 @@ module TestProf
   # FactoryProf collects "factory stacks" that can be used to build
   # flamegraphs or detect most popular factories
   module FactoryProf
-
     FACTORY_BUILDERS = [FactoryBuilders::FactoryGirl,
                         FactoryBuilders::Fabrication].freeze
 
@@ -76,7 +73,7 @@ module TestProf
 
         log :info, "FactoryProf enabled (#{config.mode} mode)"
 
-        FACTORY_BUILDERS.each { |builder| builder.patch }
+        FACTORY_BUILDERS.each(&:patch)
       end
 
       # Inits FactoryProf and setups at exit hook,

--- a/lib/test_prof/factory_prof/fabrication_patch.rb
+++ b/lib/test_prof/factory_prof/fabrication_patch.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module TestProf
+  module FactoryProf
+    # Wrap #run method with FactoryProf tracking
+    module FabricationPatch
+      def create(name, overrides={})
+        TestProf::FactoryProf::FactoryBuilders::Fabrication.track(name) { super }
+      end
+    end
+  end
+end

--- a/lib/test_prof/factory_prof/fabrication_patch.rb
+++ b/lib/test_prof/factory_prof/fabrication_patch.rb
@@ -4,8 +4,8 @@ module TestProf
   module FactoryProf
     # Wrap #run method with FactoryProf tracking
     module FabricationPatch
-      def create(name, overrides={})
-        TestProf::FactoryProf::FactoryBuilders::Fabrication.track(name) { super }
+      def create(name, overrides = {})
+        FactoryBuilders::Fabrication.track(name) { super }
       end
     end
   end

--- a/lib/test_prof/factory_prof/factory_builders/fabrication.rb
+++ b/lib/test_prof/factory_prof/factory_builders/fabrication.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module TestProf
+  module FactoryProf
+    module FactoryBuilders
+      class Fabrication
+        # Monkey-patch Fabrication
+        def self.patch
+          TestProf.require 'fabrication', ""
+          if defined?(::Fabrication)
+            ::Fabricate.singleton_class.prepend(FabricationPatch)
+          end
+        end
+
+        def self.track(factory, &block)
+          FactoryProf.track(factory, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/test_prof/factory_prof/factory_builders/fabrication.rb
+++ b/lib/test_prof/factory_prof/factory_builders/fabrication.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
+require "test_prof/factory_prof/fabrication_patch"
+
 module TestProf
   module FactoryProf
     module FactoryBuilders
+      # implementation of #patch and #track methods
+      # to provide unified interface for all factory-building gems
       class Fabrication
         # Monkey-patch Fabrication
         def self.patch
           TestProf.require 'fabrication', ""
-          if defined?(::Fabrication)
-            ::Fabricate.singleton_class.prepend(FabricationPatch)
-          end
+          ::Fabricate.singleton_class.prepend(FabricationPatch) if
+            defined?(::Fabrication)
         end
 
         def self.track(factory, &block)

--- a/lib/test_prof/factory_prof/factory_builders/factory_girl.rb
+++ b/lib/test_prof/factory_prof/factory_builders/factory_girl.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module TestProf
+  module FactoryProf
+    module FactoryBuilders
+      class FactoryGirl
+        # Monkey-patch FactoryGirl
+        def self.patch
+          if defined?(::FactoryGirl)
+            ::FactoryGirl::FactoryRunner.prepend(FactoryGirlPatch)
+          end
+        end
+
+        def self.track(strategy, factory, &block)
+          return yield unless strategy == :create
+          FactoryProf.track(factory, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/test_prof/factory_prof/factory_builders/factory_girl.rb
+++ b/lib/test_prof/factory_prof/factory_builders/factory_girl.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
+require "test_prof/factory_prof/factory_girl_patch"
+
 module TestProf
   module FactoryProf
     module FactoryBuilders
+      # implementation of #patch and #track methods
+      # to provide unified interface for all factory-building gems
       class FactoryGirl
         # Monkey-patch FactoryGirl
         def self.patch
-          if defined?(::FactoryGirl)
-            ::FactoryGirl::FactoryRunner.prepend(FactoryGirlPatch)
-          end
+          ::FactoryGirl::FactoryRunner.prepend(FactoryGirlPatch) if
+            defined?(::FactoryGirl)
         end
 
         def self.track(strategy, factory, &block)

--- a/lib/test_prof/factory_prof/factory_girl_patch.rb
+++ b/lib/test_prof/factory_prof/factory_girl_patch.rb
@@ -5,7 +5,7 @@ module TestProf
     # Wrap #run method with FactoryProf tracking
     module FactoryGirlPatch
       def run(strategy = @strategy)
-        FactoryProf.track(strategy, @name) { super }
+        TestProf::FactoryProf::FactoryBuilders::FactoryGirl.track(strategy, @name) { super }
       end
     end
   end

--- a/lib/test_prof/factory_prof/factory_girl_patch.rb
+++ b/lib/test_prof/factory_prof/factory_girl_patch.rb
@@ -5,7 +5,7 @@ module TestProf
     # Wrap #run method with FactoryProf tracking
     module FactoryGirlPatch
       def run(strategy = @strategy)
-        TestProf::FactoryProf::FactoryBuilders::FactoryGirl.track(strategy, @name) { super }
+        FactoryBuilders::FactoryGirl.track(strategy, @name) { super }
       end
     end
   end

--- a/spec/integrations/factory_prof_spec.rb
+++ b/spec/integrations/factory_prof_spec.rb
@@ -10,7 +10,7 @@ describe "FactoryProf" do
       expect(output).to include("FactoryProf enabled (simple mode)")
 
       expect(output).to include("Factories usage")
-      expect(output).to match(/total\s+top\-level\s+name\n\n\s+8\s+4\s+user\n\s+5\s+3\s+post/)
+      expect(output).to match(/total\s+top\-level\s+name\n\n\s+16\s+8\s+user\n\s+10\s+6\s+post/)
     end
 
     specify "flamegraph printer" do

--- a/spec/integrations/fixtures/rspec/factory_prof_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_prof_fixture.rb
@@ -9,30 +9,65 @@ TestProf.configure do |config|
 end
 
 describe "User" do
-  let(:user) { FactoryGirl.create(:user) }
+  context "created by factory_girl" do
+    let(:user) { FactoryGirl.create(:user) }
 
-  it "generates random names" do
-    user2 = FactoryGirl.create(:user)
-    expect(user.name).not_to eq user2.name
+    it "generates random names" do
+      user2 = FactoryGirl.create(:user)
+      expect(user.name).not_to eq user2.name
+    end
+
+    it "creates user with post" do
+      expect do
+        FactoryGirl.create(:user, :with_posts, name: 'John')
+      end.to change(Post, :count).by(2)
+    end
   end
 
-  it "creates user with post" do
-    expect do
-      FactoryGirl.create(:user, :with_posts, name: 'John')
-    end.to change(Post, :count).by(2)
+  context "created by fabrication" do
+    let(:user) { Fabricate(:user) }
+
+    it "generates random names" do
+      user2 = Fabricate(:user)
+      expect(user.name).not_to eq user2.name
+    end
+
+    it "creates user with post" do
+      expect do
+        Fabricate(:user, name: 'John') do
+          Fabricate.times(2, :post)
+        end
+      end.to change(Post, :count).by(2)
+    end
   end
 end
 
 describe "Post" do
-  let(:user) { FactoryGirl.create(:user) }
+  context "created by factory_girl" do
+    let(:user) { FactoryGirl.create(:user) }
 
-  it "creates posts with users" do
-    expect { FactoryGirl.create_pair(:post) }.to change(User, :count).by(2)
+    it "creates posts with users" do
+      expect { FactoryGirl.create_pair(:post) }.to change(User, :count).by(2)
+    end
+
+    it "creates post with defined user" do
+      user
+      expect { FactoryGirl.create(:post, user: user) }
+        .not_to change(User, :count)
+    end
   end
 
-  it "creates post with defined user" do
-    user
-    expect { FactoryGirl.create(:post, user: user) }
-      .not_to change(User, :count)
+  context "created by fabrication" do
+    let(:user) { Fabricate(:user) }
+
+    it "creates posts with users" do
+      expect { Fabricate.times(2, :post) }.to change(User, :count).by(2)
+    end
+
+    it "creates post with defined user" do
+      user
+      expect { Fabricate(:post, user: user) }
+        .not_to change(User, :count)
+    end
   end
 end

--- a/spec/support/ar_models.rb
+++ b/spec/support/ar_models.rb
@@ -2,6 +2,7 @@
 
 require "active_record"
 require "factory_girl"
+require "fabrication"
 
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
 
@@ -49,4 +50,13 @@ FactoryGirl.define do
     sequence(:text) { |n| "Post ##{n}}" }
     user
   end
+end
+
+Fabricator(:user) do
+  name Fabricate.sequence(:name) { |n| "John #{n}" }
+end
+
+Fabricator(:post) do
+  text Fabricate.sequence(:text) { |n| "Post ##{n}}" }
+  user
 end

--- a/spec/test_prof/factory_prof_spec.rb
+++ b/spec/test_prof/factory_prof_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-# Init FactoryProf and patch FactoryGirl
+# Init FactoryProf and patch FactoryGirl, Fabrication
 TestProf::FactoryProf.init
 TestProf::FactoryProf.configure do |config|
   # turn on stacks collection
@@ -19,38 +19,76 @@ describe TestProf::FactoryProf, :transactional do
   describe "#result" do
     subject(:result) { described_class.result }
 
-    it "has no stacks when no data created" do
-      FactoryGirl.build_stubbed(:user)
-      User.first
-      expect(result.stacks.size).to eq 0
+    context "when factory_girl used" do
+      it "has no stacks when no data created" do
+        FactoryGirl.build_stubbed(:user)
+        User.first
+        expect(result.stacks.size).to eq 0
+      end
+
+      it "contains simple stack" do
+        FactoryGirl.create(:user)
+        expect(result.stacks.size).to eq 1
+        expect(result.total).to eq 1
+        expect(result.stacks.first).to eq([:user])
+      end
+
+      it "contains many stacks" do
+        FactoryGirl.create_pair(:user)
+        FactoryGirl.create(:post)
+        FactoryGirl.create(:user, :with_posts)
+
+        expect(result.stacks.size).to eq 4
+        expect(result.total).to eq 9
+        expect(result.stacks).to contain_exactly(
+          [:user],
+          [:user],
+          %i[post user],
+          %i[user post user post user]
+        )
+        expect(result.stats).to eq(
+          [
+            { name: :user, total: 6, top_level: 3 },
+            { name: :post, total: 3, top_level: 1 }
+          ]
+        )
+      end
     end
 
-    it "contains simple stack" do
-      FactoryGirl.create(:user)
-      expect(result.stacks.size).to eq 1
-      expect(result.total).to eq 1
-      expect(result.stacks.first).to eq([:user])
-    end
+    context "when fabrication used" do
+      it "has no stacks when no data created" do
+        Fabricate.build(:user)
+        User.first
+        expect(result.stacks.size).to eq 0
+      end
 
-    it "contains many stacks" do
-      FactoryGirl.create_pair(:user)
-      FactoryGirl.create(:post)
-      FactoryGirl.create(:user, :with_posts)
+      it "contains simple stack" do
+        Fabricate.create(:user)
+        expect(result.stacks.size).to eq 1
+        expect(result.total).to eq 1
+        expect(result.stacks.first).to eq([:user])
+      end
 
-      expect(result.stacks.size).to eq 4
-      expect(result.total).to eq 9
-      expect(result.stacks).to contain_exactly(
-        [:user],
-        [:user],
-        %i[post user],
-        %i[user post user post user]
-      )
-      expect(result.stats).to eq(
-        [
-          { name: :user, total: 6, top_level: 3 },
-          { name: :post, total: 3, top_level: 1 }
-        ]
-      )
+      it "contains many stacks" do
+        Fabricate.times(2, :user)
+        Fabricate.create(:post)
+        Fabricate.create(:user) { Fabricate.times(2, :post) }
+
+        expect(result.stacks.size).to eq 4
+        expect(result.total).to eq 9
+        expect(result.stacks).to contain_exactly(
+          [:user],
+          [:user],
+          %i[post user],
+          %i[user post user post user]
+        )
+        expect(result.stats).to eq(
+          [
+            { name: :user, total: 6, top_level: 3 },
+            { name: :post, total: 3, top_level: 1 }
+          ]
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
### Purpose of this pull request:

 Add Fabrication gem support for FactoryProf #22 

### What changes did you make? (overview):
* extracted FactoryGirl patching method to separate class, alongside with newly created Fabrication patch;

* unified FactoryProf#track method so it does not rely on arguments passed from FactoryGirl;
 
* changed integration specs so they mimick factories created both by FactoryGirl and Fabrication;

* changed FactoryProf's unit specs and refactored similar expectations logic;

* added Fabrication fixtures;

### Is there anything you'd like reviewers to focus on?

I assumed that one app may have bundled with both FactoryGirl and Fabrication. Respective integration spec reflects this case.

I did not include neither readme updates, nor changelog entries yet. I can get them ready if the reviewers would find this PR worthy to merge.
