### PR TITLE
Fix misspellings

### DIFF
--- a/guides/any_fixture.md
+++ b/guides/any_fixture.md
@@ -112,4 +112,4 @@ include_context "article"
 include_context "author"
 ```
 
-Now we have the following affected tables list: `["articles", "authors"]`. At the end of the suite, the "authors" table is cleaned first which leads to a foreign-key violation error.
+Now we have the following affected tables list: `['articles', 'authors']`. At the end of the suite, the 'authors' table is cleaned first which leads to a foreign-key violation error.

--- a/guides/before_all.md
+++ b/guides/before_all.md
@@ -34,7 +34,7 @@ describe BeatleWeightedSearchQuery do
 end
 ```
 
-But then you have to deal with database cleaning, which can be eigher tricky or slow.
+But then you have to deal with database cleaning, which can be either tricky or slow.
 
 There is a better option: we can wrap the whole example group into a transaction.
 And that's how `before_all` works:

--- a/guides/event_prof.md
+++ b/guides/event_prof.md
@@ -95,7 +95,7 @@ end
 
 Or provide the `EVENT_PROF_EXAMPLES=1` env variable.
 
-Another useful configuration parameter – `rank_by`. It's responsible for sorting stats – 
+Another useful configuration parameter – `rank_by`. It's responsible for sorting stats –
 either by the time spent in the event or by the number of occurrences:
 
 ```sh

--- a/guides/factory_default.md
+++ b/guides/factory_default.md
@@ -1,6 +1,6 @@
 # FactoryDefault
 
-_Factory Default_ aims to help you cope with _factory cascades_ (see [FactoryProf](https://github.com/palkan/test-prof/tree/master/guides/factory_prof.md)) by re-using associated records.
+_Factory Default_ aims to help you cope with _factory cascades_ (see [FactoryProf](https://github.com/palkan/test-prof/tree/master/guides/factory_prof.md)) by reusing associated records.
 
 It can be very useful when you're working on a typical SaaS application (or other hierarchical data).
 
@@ -70,7 +70,7 @@ describe "PATCH #update" do
   let(:project) { create_default(:project) }
   let(:task) { create(:task) }
 
-  # and if need more projects, users, tasks with the same parent record,
+  # and if we need more projects, users, tasks with the same parent record,
   # we just write
   let(:another_project) { create(:project) } # uses the same account
   let(:another_task) { create(:task) } # uses the same account and the first project

--- a/guides/factory_doctor.md
+++ b/guides/factory_doctor.md
@@ -37,12 +37,12 @@ User (./spec/models/user_spec.rb:3)
   validates email (./spec/user_spec.rb:8) – 2 records created, 00:00.514
 ```
 
-**NOTE**: have you noticed the "potentially" word? Unfortunately, FactoryDoctor is not a 
+**NOTE**: have you noticed the "potentially" word? Unfortunately, FactoryDoctor is not a
 magician (it's still learning) and sometimes it produces false negatives and false positives too.
 
 Please, submit an [issue](https://github.com/palkan/test-prof/issues) if you found a case which makes FactoryDoctor fail.
 
-You can also tell FactoryDoctor to ignore specific examples/groups. Just add `:fd_ignore` tag to it:
+You can also tell FactoryDoctor to ignore specific examples/groups. Just add the `:fd_ignore` tag to it:
 
 ```ruby
 # won't be reported as offense

--- a/guides/factory_prof.md
+++ b/guides/factory_prof.md
@@ -16,7 +16,7 @@ Example output:
 
 It shows both the total number of the factory runs and the number of _top-level_ runs, i.e. not during another factory invocation (e.g. when using associations.)
 
-**NOTE**: FactoryProf only tracks the database-persisted factories. In case of FactoryFirl these are the factories
+**NOTE**: FactoryProf only tracks the database-persisted factories. In case of FactoryGirl these are the factories
 provided by using `create` strategy. In case of Fabrication - objects that created using `create` method.
 
 ## Instructions
@@ -29,7 +29,7 @@ To activate FactoryProf use `FPROF` environment variable:
 # Simple profiler
 FPROF=1 rspec
 
-# or 
+# or
 FPROF=1 bundle exec rake test
 ```
 
@@ -42,7 +42,7 @@ To generate FactoryFlame report set `FPROF` environment variable to `flamegraph`
 ```sh
 FPROF=flamegraph rspec
 
-# or 
+# or
 FPROF=flamegraph bundle exec rake test
 ```
 
@@ -52,7 +52,7 @@ That's how a report looks like:
 
 How to read this?
 
-Every column represents a _factory stack_ or _cascade_, that is a sequence of recursive `#create` method calls. Consider and example:
+Every column represents a _factory stack_ or _cascade_, that is a sequence of recursive `#create` method calls. Consider an example:
 
 ```ruby
 factory :comment do

--- a/guides/let_it_be.md
+++ b/guides/let_it_be.md
@@ -11,7 +11,7 @@ describe BeatleWeightedSearchQuery do
   let!(:george) { create(:beatle, name: 'George') }
   let!(:john) { create(:beatle, name: 'John') }
 
-  specify { expect(subject.call('joh')).to contain_exactly(john) }
+  specify { expect(subject.call('john')).to contain_exactly(john) }
 
   # and more examples here
 end
@@ -45,14 +45,13 @@ describe BeatleWeightedSearchQuery do
   let_it_be(:george) { create(:beatle, name: 'George') }
   let_it_be(:john) { create(:beatle, name: 'John') }
 
-  specify { expect(subject.call('joh')).to contain_exactly(john) }
+  specify { expect(subject.call('john')).to contain_exactly(john) }
 
   # and more examples here
 end
 ```
 
 That's it! Just replace `let!` with `let_it_be`. That's equal to the `before_all` approach but requires less refactoring.
-
 
 ## Instructions
 

--- a/guides/rspec_dissect.md
+++ b/guides/rspec_dissect.md
@@ -1,6 +1,6 @@
 # RSpecDissect
 
-Do you know how much time you spend in `before` hooks? Or memoization helpers such as `let`? Usually, the most of the whole test suite time.
+Do you know how much time you spend in `before` hooks? Or in memoization helpers such as `let`? Usually, the most of the whole test suite time.
 
 _RSpecDissect_ provides this kind of information and also shows you the worst example groups. The main purpose of RSpecDissect is to identify these slow groups and refactor them using [`before_all`](https://github.com/palkan/test-prof/tree/master/guides/before_all.md) or [`let_it_be`](https://github.com/palkan/test-prof/tree/master/guides/let_it_be.md) recipes.
 

--- a/guides/rspec_stamp.md
+++ b/guides/rspec_stamp.md
@@ -1,10 +1,10 @@
-# RSpec Stamp
+# RSpecStamp
 
-RSpec Stamp is a tool to automatically _tag_ failed examples with custom tags.
+RSpecStamp is a tool to automatically _tag_ failed examples with custom tags.
 
 It _literally_ adds tags to your examples (i.e. rewrites them).
 
-The main purpose of RSpec Stamp is to make refactoring testing codebase easy. Changing global configuration may cause a lot of failures. You can patch failing spec by adding a shared context. And here comes RSpec Stamp.
+The main purpose of RSpecStamp is to make testing codebase refactoring easy. Changing global configuration may cause a lot of failures. You can patch failing spec by adding a shared context. And here comes RSpecStamp.
 
 ## Example Use Case: Sidekiq Inline
 
@@ -38,7 +38,7 @@ The output of the command above contains information about the _stamping_ proces
 
 Now all (or almost all) failing specs are tagged with `sidekiq: :inline`. Run the whole suite again and check it there are any failures left.
 
-There is also a _dry-run_ mode (activated by `RSTAMP_DRY_RUN=1` env variable) which prints out patches instead of re-writing files.
+There is also a `dry-run` mode (activated by `RSTAMP_DRY_RUN=1` env variable) which prints out patches instead of re-writing files.
 
 ## Configuration
 
@@ -50,4 +50,3 @@ TestProf::RSpecStamp.configure do |config|
   config.ignore_files << %r{spec/my_directory}
 end
 ```
-

--- a/guides/ruby_prof.md
+++ b/guides/ruby_prof.md
@@ -13,7 +13,7 @@ group :development, :test do
 end
 ```
 
-RubyProf profiler has two modes: _global_ and _per-example_.
+RubyProf profiler has two modes: `global` and `per-example`.
 
 You can activate the global profiling using the environment variable `TEST_RUBY_PROF`:
 

--- a/guides/stack_prof.md
+++ b/guides/stack_prof.md
@@ -4,7 +4,7 @@
 
 ## Instructions
 
-Install 'stackprof' gem (>= 0.2.9):
+Install `stackprof` gem (>= 0.2.9):
 
 ```ruby
 # Gemfile
@@ -13,9 +13,9 @@ group :development, :test do
 end
 ```
 
-StackProf profiler has 2 modes: _global_ and _per-example_.
+StackProf profiler has 2 modes: `global` and `per-example`.
 
-You can activate the global profiling using the environment variable `TEST_STACK_PROF`:
+You can activate global profiling using the environment variable `TEST_STACK_PROF`:
 
 ```sh
 TEST_STACK_PROF=1 bundle exec rake test


### PR DESCRIPTION
This fixes:
- Some misspellings and errors
- Quotes in Ruby code examples to fit the style guide