### PR TITLE
FactoryProf: Do not display error message when Fabrication gem is not installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /tmp/
 *.gem
 gemfiles/*.lock
+spec/integrations/fixtures/rspec/tmp/
+spec/integrations/fixtures/rspec/gemfiles/*.lock

--- a/lib/test_prof.rb
+++ b/lib/test_prof.rb
@@ -47,11 +47,11 @@ module TestProf
 
     # Require gem and shows a custom
     # message if it fails to load
-    def require(gem_name, msg)
+    def require(gem_name, msg = nil)
       Kernel.require gem_name
       block_given? ? yield : true
     rescue LoadError
-      log :error, msg
+      log(:error, msg) if msg
       false
     end
 

--- a/lib/test_prof/factory_prof/factory_builders/fabrication.rb
+++ b/lib/test_prof/factory_prof/factory_builders/fabrication.rb
@@ -10,9 +10,9 @@ module TestProf
       class Fabrication
         # Monkey-patch Fabrication
         def self.patch
-          TestProf.require 'fabrication', ""
-          ::Fabricate.singleton_class.prepend(FabricationPatch) if
-            defined?(::Fabrication)
+          TestProf.require 'fabrication' do
+            ::Fabricate.singleton_class.prepend(FabricationPatch)
+          end
         end
 
         def self.track(factory, &block)

--- a/lib/test_prof/factory_prof/factory_builders/factory_girl.rb
+++ b/lib/test_prof/factory_prof/factory_builders/factory_girl.rb
@@ -10,8 +10,9 @@ module TestProf
       class FactoryGirl
         # Monkey-patch FactoryGirl
         def self.patch
-          ::FactoryGirl::FactoryRunner.prepend(FactoryGirlPatch) if
-            defined?(::FactoryGirl)
+          TestProf.require 'factory_girl' do
+            ::FactoryGirl::FactoryRunner.prepend(FactoryGirlPatch)
+          end
         end
 
         def self.track(strategy, factory, &block)

--- a/lib/test_prof/factory_prof/printers/flamegraph.rb
+++ b/lib/test_prof/factory_prof/printers/flamegraph.rb
@@ -9,6 +9,7 @@ module TestProf::FactoryProf
         include TestProf::Logging
 
         def dump(result)
+          return log(:info, "No factories detected") if result.raw_stats == {}
           report_data = {
             total_stacks: result.stacks.size,
             total: result.total

--- a/lib/test_prof/factory_prof/printers/simple.rb
+++ b/lib/test_prof/factory_prof/printers/simple.rb
@@ -10,6 +10,7 @@ module TestProf::FactoryProf
         using TestProf::StringStripHeredoc
 
         def dump(result)
+          return log(:info, "No factories detected") if result.raw_stats == {}
           msgs = []
 
           msgs <<

--- a/spec/integrations/factory_prof_spec.rb
+++ b/spec/integrations/factory_prof_spec.rb
@@ -22,5 +22,45 @@ describe "FactoryProf" do
 
       expect(File.exist?("tmp/factory-flame.html")).to eq true
     end
+
+    context "when no fabrication installed" do
+      specify "simple printer", :aggregate_failures do
+        output = run_rspec_with_clean_env('factory_prof_no_fabrication',
+                                          env: { 'FPROF' => '1',
+                                                 'BUNDLE_GEMFILE' => gemfile_name('no_fabrication') })
+        expect(output).to include("FactoryProf enabled (simple mode)")
+        expect(output).to include("No factories detected")
+        expect(output).not_to include("[TEST PROF ERROR]")
+      end
+
+      specify "flamegraph printer" do
+        output = run_rspec_with_clean_env('factory_prof_no_fabrication',
+                                          env: { 'FPROF' => 'flamegraph',
+                                                 'BUNDLE_GEMFILE' => gemfile_name('no_fabrication') })
+        expect(output).to include("FactoryProf enabled (flamegraph mode)")
+        expect(output).to include("No factories detected")
+        expect(output).not_to include("[TEST PROF ERROR]")
+      end
+    end
+
+    context "when no factory_girl installed" do
+      specify "simple printer", :aggregate_failures do
+        output = run_rspec_with_clean_env('factory_prof_no_factory_girl',
+                                          env: { 'FPROF' => '1',
+                                                 'BUNDLE_GEMFILE' => gemfile_name('no_factory_girl') })
+        expect(output).to include("FactoryProf enabled (simple mode)")
+        expect(output).to include("No factories detected")
+        expect(output).not_to include("[TEST PROF ERROR]")
+      end
+
+      specify "flamegraph printer" do
+        output = run_rspec_with_clean_env('factory_prof_no_factory_girl',
+                                          env: { 'FPROF' => 'flamegraph',
+                                                 'BUNDLE_GEMFILE' => gemfile_name('no_factory_girl') })
+        expect(output).to include("FactoryProf enabled (flamegraph mode)")
+        expect(output).to include("No factories detected")
+        expect(output).not_to include("[TEST PROF ERROR]")
+      end
+    end
   end
 end

--- a/spec/integrations/fixtures/rspec/factory_prof_no_fabrication_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_prof_no_fabrication_fixture.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
+require "test-prof"
+
+context "when no fabrication installed" do
+  it "do nothing" do
+    expect { Fabricate(:user) }.to raise_error(NameError)
+    expect(true).to eq true
+  end
+end

--- a/spec/integrations/fixtures/rspec/factory_prof_no_factory_girl_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_prof_no_factory_girl_fixture.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
+require "test-prof"
+
+context "when no factory_girl installed" do
+  it "do nothing" do
+    expect { FactoryGirl.create(:user) }.to raise_error(NameError)
+    expect(true).to eq true
+  end
+end

--- a/spec/integrations/fixtures/rspec/gemfiles/no_fabrication_activerecord42.gemfile
+++ b/spec/integrations/fixtures/rspec/gemfiles/no_fabrication_activerecord42.gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in test-prof.gemspec
+gemspec path: '../../../../../'
+
+gem 'activerecord', '~> 4.2'
+gem "factory_girl", "~> 4.8.0"
+gem "sqlite3"
+gem "sidekiq", "~> 3.0"
+gem "timecop", "~> 0.9.1"

--- a/spec/integrations/fixtures/rspec/gemfiles/no_fabrication_default.gemfile
+++ b/spec/integrations/fixtures/rspec/gemfiles/no_fabrication_default.gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in test-prof.gemspec
+gemspec path: '../../../../../'
+
+gem "activerecord", "~> 5.0"
+gem "factory_girl", "~> 4.8.0"
+gem "sqlite3"
+gem "sidekiq", "~> 4.0"
+gem "timecop", "~> 0.9.1"

--- a/spec/integrations/fixtures/rspec/gemfiles/no_fabrication_jruby.gemfile
+++ b/spec/integrations/fixtures/rspec/gemfiles/no_fabrication_jruby.gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in test-prof.gemspec
+gemspec path: '../../../../../'
+
+gem "activerecord-jdbcsqlite3-adapter"
+gem "activerecord", "~> 4.2"
+
+gem "factory_girl", "~> 4.8.0"
+
+gem "sidekiq", "~> 4.0"
+gem "timecop", "~> 0.9.1"

--- a/spec/integrations/fixtures/rspec/gemfiles/no_fabrication_railsmaster.gemfile
+++ b/spec/integrations/fixtures/rspec/gemfiles/no_fabrication_railsmaster.gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in test-prof.gemspec
+gemspec path: '../../../../../'
+
+gem 'arel', git: 'https://github.com/rails/arel.git'
+gem 'rails', git: 'https://github.com/rails/rails.git'
+gem "factory_girl", "~> 4.8.0"
+gem "sqlite3"
+gem "sidekiq", "~> 4.0"
+gem "timecop", "~> 0.9.1"
+

--- a/spec/integrations/fixtures/rspec/gemfiles/no_factory_girl_activerecord42.gemfile
+++ b/spec/integrations/fixtures/rspec/gemfiles/no_factory_girl_activerecord42.gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in test-prof.gemspec
+gemspec path: '../../../../../'
+
+gem 'activerecord', '~> 4.2'
+gem "fabrication"
+gem "sqlite3"
+gem "sidekiq", "~> 3.0"
+gem "timecop", "~> 0.9.1"

--- a/spec/integrations/fixtures/rspec/gemfiles/no_factory_girl_default.gemfile
+++ b/spec/integrations/fixtures/rspec/gemfiles/no_factory_girl_default.gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in test-prof.gemspec
+gemspec path: '../../../../../'
+
+gem "activerecord", "~> 5.0"
+gem "fabrication"
+gem "sqlite3"
+gem "sidekiq", "~> 4.0"
+gem "timecop", "~> 0.9.1"

--- a/spec/integrations/fixtures/rspec/gemfiles/no_factory_girl_jruby.gemfile
+++ b/spec/integrations/fixtures/rspec/gemfiles/no_factory_girl_jruby.gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in test-prof.gemspec
+gemspec path: '../../../../../'
+
+gem "activerecord-jdbcsqlite3-adapter"
+gem "activerecord", "~> 4.2"
+
+gem "fabrication"
+
+gem "sidekiq", "~> 4.0"
+gem "timecop", "~> 0.9.1"

--- a/spec/integrations/fixtures/rspec/gemfiles/no_factory_girl_railsmaster.gemfile
+++ b/spec/integrations/fixtures/rspec/gemfiles/no_factory_girl_railsmaster.gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in test-prof.gemspec
+gemspec path: '../../../../../'
+
+gem 'arel', git: 'https://github.com/rails/arel.git'
+gem 'rails', git: 'https://github.com/rails/rails.git'
+gem "fabrication"
+gem "sqlite3"
+gem "sidekiq", "~> 4.0"
+gem "timecop", "~> 0.9.1"
+

--- a/spec/support/integration_helpers.rb
+++ b/spec/support/integration_helpers.rb
@@ -11,6 +11,18 @@ module IntegrationHelpers
     output
   end
 
+  def run_rspec_with_clean_env(path, chdir: nil, success: true, env: {})
+    output, status = Bundler.with_clean_env do
+      Open3.capture2(
+        env,
+        "rspec #{path}_fixture.rb",
+        chdir: chdir || File.expand_path("../../integrations/fixtures/rspec", __FILE__)
+      )
+    end
+    expect(status).to be_success, "Test #{path} failed with: #{output}" if success
+    output
+  end
+
   def run_minitest(path, chdir: nil, success: true, env: {})
     output, status = Open3.capture2(
       env,
@@ -19,5 +31,17 @@ module IntegrationHelpers
     )
     expect(status).to be_success, "Test #{path} failed with: #{output}" if success
     output
+  end
+
+  def gemfile_name(name)
+    if RUBY_PLATFORM == "java"
+      "gemfiles/#{name}_jruby.gemfile"
+    elsif RUBY_VERSION.start_with?("2.3", "2.4")
+      "gemfiles/#{name}_default.gemfile"
+    elsif RUBY_VERSION.start_with?("2.2")
+      "gemfiles/#{name}_activerecord42.gemfile"
+    else
+      "gemfiles/#{name}_railsmaster.gemfile"
+    end
   end
 end

--- a/spec/test_prof_spec.rb
+++ b/spec/test_prof_spec.rb
@@ -32,4 +32,70 @@ describe TestProf do
       it { expect(described_class.artifact_path("c")).to eq 'tmp/test/c-123454321' }
     end
   end
+
+  describe "#require" do
+    context "when second argument omitted" do
+      context "when Kernel.require fails" do
+        it "returns false without logging" do
+          allow(Kernel).to receive(:require).with("non-existent").and_raise(LoadError)
+          allow(described_class).to receive(:require).with("non-existent")
+                                                     .and_call_original
+          expect(described_class.require("non-existent")).to eq false
+          expect(described_class).not_to receive(:log).with(:error, nil)
+          described_class.require("non-existent", nil)
+        end
+      end
+
+      context "when Kernel.require succeeds" do
+        context "when block given" do
+          it "yields block" do
+            allow(Kernel).to receive(:require).with("something").and_return(true)
+            allow(described_class).to receive(:require).with("something") { 2 + 2 }
+                                                       .and_call_original
+            expect(described_class.require("something") { 2 + 2 }).to eq 4
+          end
+        end
+
+        context "when no block given" do
+          it "returns true" do
+            allow(Kernel).to receive(:require).with("something").and_return(true)
+            allow(described_class).to receive(:require).with("something").and_call_original
+            expect(described_class.require("something")).to eq true
+          end
+        end
+      end
+    end
+
+    context "when two arguments supplied" do
+      context "when Kernel.require fails" do
+        it "returns false with log output" do
+          allow(Kernel).to receive(:require).with("non-existent").and_raise(LoadError)
+          allow(described_class).to receive(:require).with("non-existent", "message")
+                                                     .and_call_original
+          expect(described_class.require("non-existent", "message")).to eq false
+          expect(described_class).to receive(:log).with(:error, "message")
+          described_class.require("non-existent", "message")
+        end
+      end
+
+      context "when Kernel.require succeeds" do
+        context "when block given" do
+          it "yields block" do
+            allow(Kernel).to receive(:require).with("something").and_return(true)
+            allow(described_class).to receive(:require).with("something", "message") { 2 + 2 }
+                                                       .and_call_original
+            expect(described_class.require("something", "message") { 2 + 2 }).to eq 4
+          end
+        end
+
+        context "when no block given" do
+          it "returns true" do
+            allow(Kernel).to receive(:require).with("something").and_return(true)
+            allow(described_class).to receive(:require).with("something").and_call_original
+            expect(described_class.require("something")).to eq true
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
 Fixes #40. Remove from logs confusing empty error message caused by missing fabrication gem.