### PR TITLE
Migration from FactoryGirl to FactoryBot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ matrix:
     - rvm: jruby-9.1.0.0
       gemfile: gemfiles/jruby.gemfile
     - rvm: 2.4.1
-      gemfile: Gemfile
+      gemfile:
+        - Gemfile
+        - gemfiles/default_factory_girl.gemfile
     - rvm: 2.4.1
       gemfile: gemfiles/rspec32.gemfile
     - rvm: 2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## master branch
+
+- [#46](https://github.com/palkan/test-prof/pull/46) Support FactoryBot, which is [former FactoryGirl](https://github.com/thoughtbot/factory_bot/pull/1051), 
+  while maintaining compatibility with latter. ([@Shkrt][])
+
 ## 0.4.2
 
 - Fix bug with multiple `before_all` within one group. ([@palkan][])

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 gem "sqlite3"
 gem "activerecord", "~> 5.0"
 
-gem "factory_girl", "~> 4.8.0"
+gem "factory_bot", "~> 4.8.0"
 gem "fabrication"
 
 gem "sidekiq", "~> 4.0"

--- a/gemfiles/activerecord42.gemfile
+++ b/gemfiles/activerecord42.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 4.2'
-gem "factory_girl", "~> 4.8.0"
+gem "factory_bot", "~> 4.8.0"
 gem "fabrication"
 gem "sqlite3"
 gem "sidekiq", "~> 3.0"

--- a/gemfiles/default_factory_girl.gemfile
+++ b/gemfiles/default_factory_girl.gemfile
@@ -3,12 +3,12 @@ source 'https://rubygems.org'
 gem "sqlite3"
 gem "activerecord", "~> 5.0"
 
-gem "factory_bot", "~> 4.8.0"
+gem "factory_girl", "~> 4.8.0"
 gem "fabrication"
 
 gem "sidekiq", "~> 4.0"
 gem "timecop", "~> 0.9.1"
 
-gem "rspec", "~> 3.3.0"
+gem "pry-byebug"
 
 gemspec path: '..'

--- a/gemfiles/jruby.gemfile
+++ b/gemfiles/jruby.gemfile
@@ -6,7 +6,7 @@ gem "activerecord-jdbcsqlite3-adapter"
 # see https://github.com/jruby/activerecord-jdbc-adapter/issues/747
 gem "activerecord", "~> 4.2"
 
-gem "factory_girl", "~> 4.8.0"
+gem "factory_bot", "~> 4.8.0"
 gem "fabrication"
 
 gem "sidekiq", "~> 4.0"

--- a/gemfiles/railsmaster.gemfile
+++ b/gemfiles/railsmaster.gemfile
@@ -3,8 +3,7 @@ source 'https://rubygems.org'
 gem 'arel', github: 'rails/arel'
 gem 'rails', github: 'rails/rails'
 gem "fabrication"
-gem "factory_girl", "~> 4.8.0"
-gem "factory_bot"
+gem "factory_bot", "~> 4.8.0"
 gem "sqlite3"
 gem "sidekiq", "~> 4.0"
 gem "timecop", "~> 0.9.1"

--- a/gemfiles/railsmaster.gemfile
+++ b/gemfiles/railsmaster.gemfile
@@ -4,6 +4,7 @@ gem 'arel', github: 'rails/arel'
 gem 'rails', github: 'rails/rails'
 gem "fabrication"
 gem "factory_girl", "~> 4.8.0"
+gem "factory_bot"
 gem "sqlite3"
 gem "sidekiq", "~> 4.0"
 gem "timecop", "~> 0.9.1"

--- a/gemfiles/rspec32.gemfile
+++ b/gemfiles/rspec32.gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem "sqlite3"
 gem "activerecord", "~> 5.0"
 
-gem "factory_girl", "~> 4.8.0"
+gem "factory_bot", "~> 4.8.0"
 gem "fabrication"
 
 gem "sidekiq", "~> 4.0"

--- a/lib/test_prof/event_prof/custom_events/factory_create.rb
+++ b/lib/test_prof/event_prof/custom_events/factory_create.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_prof/ext/string_strip_heredoc"
+require "test_prof/factory_bot"
 
 using TestProf::StringStripHeredoc
 
@@ -18,7 +19,7 @@ module TestProf::EventProf::CustomEvents
     class << self
       def setup!
         @depth = 0
-        FactoryGirl::FactoryRunner.prepend RunnerPatch
+        TestProf::FactoryBot::FactoryRunner.prepend RunnerPatch
       end
 
       def track(factory)
@@ -45,11 +46,11 @@ end
 
 TestProf.activate('EVENT_PROF', 'factory.create') do
   if TestProf.require(
-    'factory_girl',
+    'factory_bot',
     <<-MSG.strip_heredoc
-      Failed to load FactoryGirl.
+      Failed to load FactoryBot.
 
-      Make sure that "factory_girl" gem is in your Gemfile.
+      Make sure that "factory_bot" gem is in your Gemfile.
     MSG
   )
     TestProf::EventProf::CustomEvents::FactoryCreate.setup!

--- a/lib/test_prof/event_prof/custom_events/factory_create.rb
+++ b/lib/test_prof/event_prof/custom_events/factory_create.rb
@@ -45,14 +45,15 @@ module TestProf::EventProf::CustomEvents
 end
 
 TestProf.activate('EVENT_PROF', 'factory.create') do
-  if TestProf.require(
-    'factory_bot',
-    <<-MSG.strip_heredoc
-      Failed to load FactoryBot.
-
-      Make sure that "factory_bot" gem is in your Gemfile.
-    MSG
-  )
+  if defined? TestProf::FactoryBot
     TestProf::EventProf::CustomEvents::FactoryCreate.setup!
+  else
+    TestProf.log(:error,
+                 <<-MSG.strip_heredoc
+                   Failed to load factory_bot / factory_girl.
+
+                   Make sure that any of them is in your Gemfile.
+                 MSG
+                )
   end
 end

--- a/lib/test_prof/factory_bot.rb
+++ b/lib/test_prof/factory_bot.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-CONSTANT_NAMES = { 'factory_bot' => '::FactoryBot', 'factory_girl' => '::FactoryGirl' }.freeze
+module TestProf # :nodoc: all
+  FACTORY_GIRL_NAMES = { 'factory_bot' => '::FactoryBot', 'factory_girl' => '::FactoryGirl' }.freeze
 
-CONSTANT_NAMES.keys.each do |name|
-  result = TestProf.require(name) do
-    Object.const_get(CONSTANT_NAMES[name])
+  FACTORY_GIRL_NAMES.find do |name, cname|
+    TestProf.require(name) do
+      TestProf::FactoryBot = Object.const_get(cname)
+    end
   end
-  return TestProf::FactoryBot = result if result
 end

--- a/lib/test_prof/factory_bot.rb
+++ b/lib/test_prof/factory_bot.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+CONSTANT_NAMES = { 'factory_bot' => '::FactoryBot', 'factory_girl' => '::FactoryGirl' }.freeze
+
+CONSTANT_NAMES.keys.each do |name|
+  result = TestProf.require(name) do
+    Object.const_get(CONSTANT_NAMES[name])
+  end
+  return TestProf::FactoryBot = result if result
+end

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "test_prof/factory_default/factory_girl_patch"
+require "test_prof/factory_default/factory_bot_patch"
 
 module TestProf
   # FactoryDefault allows use to re-use associated objects
@@ -10,7 +10,7 @@ module TestProf
       def create_default(name, *args, &block)
         set_factory_default(
           name,
-          FactoryGirl.create(name, *args, &block)
+          TestProf::FactoryBot.create(name, *args, &block)
         )
       end
 
@@ -21,11 +21,11 @@ module TestProf
 
     class << self
       def init
-        FactoryGirl::Syntax::Methods.include DefaultSyntax
-        FactoryGirl.extend DefaultSyntax
-        FactoryGirl::Strategy::Create.prepend StrategyExt
-        FactoryGirl::Strategy::Build.prepend StrategyExt
-        FactoryGirl::Strategy::Stub.prepend StrategyExt
+        TestProf::FactoryBot::Syntax::Methods.include DefaultSyntax
+        TestProf::FactoryBot.extend DefaultSyntax
+        TestProf::FactoryBot::Strategy::Create.prepend StrategyExt
+        TestProf::FactoryBot::Strategy::Build.prepend StrategyExt
+        TestProf::FactoryBot::Strategy::Stub.prepend StrategyExt
 
         @store = {}
       end

--- a/lib/test_prof/factory_default/factory_bot_patch.rb
+++ b/lib/test_prof/factory_default/factory_bot_patch.rb
@@ -3,7 +3,7 @@
 module TestProf
   module FactoryDefault # :nodoc: all
     module RunnerExt
-      refine FactoryGirl::FactoryRunner do
+      refine TestProf::FactoryBot::FactoryRunner do
         def name
           @name
         end

--- a/lib/test_prof/factory_doctor.rb
+++ b/lib/test_prof/factory_doctor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "test_prof/factory_doctor/factory_girl_patch"
+require "test_prof/factory_doctor/factory_bot_patch"
 
 module TestProf
   # FactoryDoctor is a tool that helps you identify
@@ -49,9 +49,9 @@ module TestProf
 
         log :info, "FactoryDoctor enabled"
 
-        # Monkey-patch FactoryGirl
-        ::FactoryGirl::FactoryRunner.prepend(FactoryGirlPatch) if
-          defined?(::FactoryGirl)
+        # Monkey-patch FactoryBot / FactoryGirl
+        TestProf::FactoryBot::FactoryRunner.prepend(FactoryBotPatch) if
+          defined?(TestProf::FactoryBot)
 
         subscribe!
 

--- a/lib/test_prof/factory_doctor/factory_bot_patch.rb
+++ b/lib/test_prof/factory_doctor/factory_bot_patch.rb
@@ -3,7 +3,7 @@
 module TestProf
   module FactoryDoctor
     # Wrap #run method with FactoryDoctor tracking
-    module FactoryGirlPatch
+    module FactoryBotPatch
       def run(strategy = @strategy)
         FactoryDoctor.within_factory(strategy) { super }
       end

--- a/lib/test_prof/factory_prof.rb
+++ b/lib/test_prof/factory_prof.rb
@@ -2,14 +2,14 @@
 
 require "test_prof/factory_prof/printers/simple"
 require "test_prof/factory_prof/printers/flamegraph"
-require "test_prof/factory_prof/factory_builders/factory_girl"
+require "test_prof/factory_prof/factory_builders/factory_bot"
 require "test_prof/factory_prof/factory_builders/fabrication"
 
 module TestProf
   # FactoryProf collects "factory stacks" that can be used to build
   # flamegraphs or detect most popular factories
   module FactoryProf
-    FACTORY_BUILDERS = [FactoryBuilders::FactoryGirl,
+    FACTORY_BUILDERS = [FactoryBuilders::FactoryBot,
                         FactoryBuilders::Fabrication].freeze
 
     # FactoryProf configuration

--- a/lib/test_prof/factory_prof/factory_bot_patch.rb
+++ b/lib/test_prof/factory_prof/factory_bot_patch.rb
@@ -3,9 +3,9 @@
 module TestProf
   module FactoryProf
     # Wrap #run method with FactoryProf tracking
-    module FactoryGirlPatch
+    module FactoryBotPatch
       def run(strategy = @strategy)
-        FactoryBuilders::FactoryGirl.track(strategy, @name) { super }
+        FactoryBuilders::FactoryBot.track(strategy, @name) { super }
       end
     end
   end

--- a/lib/test_prof/factory_prof/factory_builders/factory_bot.rb
+++ b/lib/test_prof/factory_prof/factory_builders/factory_bot.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require "test_prof/factory_prof/factory_girl_patch"
+require "test_prof/factory_prof/factory_bot_patch"
+require "test_prof/factory_bot"
 
 module TestProf
   module FactoryProf
     module FactoryBuilders
       # implementation of #patch and #track methods
       # to provide unified interface for all factory-building gems
-      class FactoryGirl
-        # Monkey-patch FactoryGirl
+      class FactoryBot
+        # Monkey-patch FactoryBot / FactoryGirl
         def self.patch
-          TestProf.require 'factory_girl' do
-            ::FactoryGirl::FactoryRunner.prepend(FactoryGirlPatch)
-          end
+          TestProf::FactoryBot::FactoryRunner.prepend(FactoryBotPatch) if
+            defined? TestProf::FactoryBot
         end
 
         def self.track(strategy, factory, &block)

--- a/spec/integrations/factory_prof_spec.rb
+++ b/spec/integrations/factory_prof_spec.rb
@@ -32,9 +32,9 @@ describe "FactoryProf" do
       end
     end
 
-    context "when no factory_girl installed" do
+    context "when no factory_bot installed" do
       specify "simple printer", :aggregate_failures do
-        output = run_rspec('factory_prof_no_factory_girl', env: { 'FPROF' => '1' })
+        output = run_rspec('factory_prof_no_factory_bot', env: { 'FPROF' => '1' })
         expect(output).to include("FactoryProf enabled (simple mode)")
         expect(output).to include("No factories detected")
         expect(output).not_to include("[TEST PROF ERROR]")

--- a/spec/integrations/fixtures/minitest/event_prof_factory_create_fixture.rb
+++ b/spec/integrations/fixtures/minitest/event_prof_factory_create_fixture.rb
@@ -6,16 +6,16 @@ require 'minitest/autorun'
 require "test-prof"
 
 describe "Post" do
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { TestProf::FactoryBot.create(:user) }
 
   it "generates random names" do
-    user2 = FactoryGirl.create(:post).user
+    user2 = TestProf::FactoryBot.create(:post).user
     refute_equal user.name, user2.name
   end
 end
 
 describe "User" do
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { TestProf::FactoryBot.create(:user) }
 
   it "validates name" do
     user.name = ''

--- a/spec/integrations/fixtures/minitest/factory_doctor_fixture.rb
+++ b/spec/integrations/fixtures/minitest/factory_doctor_fixture.rb
@@ -7,11 +7,11 @@ require "test-prof"
 
 describe "User" do
   before do
-    @user = FactoryGirl.create(:user)
+    @user = TestProf::FactoryBot.create(:user)
   end
 
   it "generates random names" do
-    user2 = FactoryGirl.create(:user)
+    user2 = TestProf::FactoryBot.create(:user)
     refute_equal @user.name, user2.name
   end
 
@@ -21,7 +21,7 @@ describe "User" do
   end
 
   it "creates and reloads user" do
-    @user = FactoryGirl.create(:user, name: 'John')
+    @user = TestProf::FactoryBot.create(:user, name: 'John')
     assert User.find(@user.id).name, 'John'
   end
 

--- a/spec/integrations/fixtures/rspec/.byebug_history
+++ b/spec/integrations/fixtures/rspec/.byebug_history
@@ -1,0 +1,1 @@
+continue

--- a/spec/integrations/fixtures/rspec/.byebug_history
+++ b/spec/integrations/fixtures/rspec/.byebug_history
@@ -1,1 +1,0 @@
-continue

--- a/spec/integrations/fixtures/rspec/any_fixture_fixture.rb
+++ b/spec/integrations/fixtures/rspec/any_fixture_fixture.rb
@@ -8,7 +8,7 @@ require "test_prof/recipes/rspec/any_fixture"
 shared_context "user", user: true do
   before(:all) do
     @user = TestProf::AnyFixture.register(:user) do
-      FactoryGirl.create(:user)
+      TestProf::FactoryBot.create(:user)
     end
   end
 
@@ -29,7 +29,7 @@ describe "User", :user do
 end
 
 describe "Post", :user do
-  let(:post) { FactoryGirl.create(:post, user: user) }
+  let(:post) { TestProf::FactoryBot.create(:post, user: user) }
   after { post.destroy }
 
   it "creates post with the same user" do

--- a/spec/integrations/fixtures/rspec/before_all_fixture.rb
+++ b/spec/integrations/fixtures/rspec/before_all_fixture.rb
@@ -8,7 +8,7 @@ require "test_prof/recipes/rspec/before_all"
 describe "User", :transactional do
   context "with before_all" do
     before_all do
-      @user = FactoryGirl.create(:user)
+      @user = TestProf::FactoryBot.create(:user)
     end
 
     let(:user) { User.find(@user.id) }
@@ -33,7 +33,7 @@ describe "User", :transactional do
 
   context "inner before_all" do
     before_all do
-      @user2 = FactoryGirl.create(:user)
+      @user2 = TestProf::FactoryBot.create(:user)
     end
 
     specify { expect(User.find(@user2.id)).to be_a(User) }
@@ -43,11 +43,11 @@ describe "User", :transactional do
 
   context "multiple before_all" do
     before_all do
-      @user2 = FactoryGirl.create(:user)
+      @user2 = TestProf::FactoryBot.create(:user)
     end
 
     before_all do
-      @user3 = FactoryGirl.create(:user)
+      @user3 = TestProf::FactoryBot.create(:user)
     end
 
     specify { expect(User.find(@user2.id)).to be_a(User) }

--- a/spec/integrations/fixtures/rspec/event_prof_factory_create_fixture.rb
+++ b/spec/integrations/fixtures/rspec/event_prof_factory_create_fixture.rb
@@ -5,16 +5,16 @@ require_relative "../../../support/ar_models"
 require "test-prof"
 
 describe "Post" do
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { TestProf::FactoryBot.create(:user) }
 
   it "generates random names" do
-    user2 = FactoryGirl.create(:post).user
+    user2 = TestProf::FactoryBot.create(:post).user
     expect(user.name).not_to eq user2.name
   end
 end
 
 describe "User" do
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { TestProf::FactoryBot.create(:user) }
 
   it "validates name" do
     user.name = ''

--- a/spec/integrations/fixtures/rspec/factory_default_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_default_fixture.rb
@@ -6,8 +6,8 @@ require_relative "../../../support/transactional_context"
 require "test_prof/recipes/rspec/factory_default"
 
 describe "Post" do
-  let(:user) { FactoryGirl.create_default(:user) }
-  let(:post) { FactoryGirl.create(:post) }
+  let(:user) { TestProf::FactoryBot.create_default(:user) }
+  let(:post) { TestProf::FactoryBot.create(:post) }
 
   it "creates post with the same user" do
     user
@@ -21,21 +21,21 @@ describe "Post" do
 
   it "works with many records" do
     user
-    expect { FactoryGirl.create_list(:post, 5) }.not_to change(User, :count)
+    expect { TestProf::FactoryBot.create_list(:post, 5) }.not_to change(User, :count)
     expect(user.posts.count).to eq 5
   end
 
   it "works with specified user" do
     user
-    user2 = FactoryGirl.create(:user)
-    post = FactoryGirl.create(:post, user: user2)
+    user2 = TestProf::FactoryBot.create(:user)
+    post = TestProf::FactoryBot.create(:post, user: user2)
     expect(post.user).to eq user2
   end
 
   context "with redefined user" do
-    let(:user2) { FactoryGirl.create(:user) }
+    let(:user2) { TestProf::FactoryBot.create(:user) }
 
-    before { FactoryGirl.set_factory_default(:user, user2) }
+    before { TestProf::FactoryBot.set_factory_default(:user, user2) }
 
     it "uses redefined default" do
       expect(post.user).to eq user2

--- a/spec/integrations/fixtures/rspec/factory_doctor_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_doctor_fixture.rb
@@ -5,10 +5,10 @@ require_relative "../../../support/ar_models"
 require "test-prof"
 
 describe "User" do
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { TestProf::FactoryBot.create(:user) }
 
   it "generates random names" do
-    user2 = FactoryGirl.create(:user)
+    user2 = TestProf::FactoryBot.create(:user)
     expect(user.name).not_to eq user2.name
   end
 
@@ -18,7 +18,7 @@ describe "User" do
   end
 
   it "creates and reloads user" do
-    user = FactoryGirl.create(:user, name: 'John')
+    user = TestProf::FactoryBot.create(:user, name: 'John')
     expect(User.find(user.id).name).to eq 'John'
   end
 

--- a/spec/integrations/fixtures/rspec/factory_prof_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_prof_fixture.rb
@@ -9,17 +9,17 @@ TestProf.configure do |config|
 end
 
 describe "User" do
-  context "created by factory_girl" do
-    let(:user) { FactoryGirl.create(:user) }
+  context "created by factory_bot" do
+    let(:user) { TestProf::FactoryBot.create(:user) }
 
     it "generates random names" do
-      user2 = FactoryGirl.create(:user)
+      user2 = TestProf::FactoryBot.create(:user)
       expect(user.name).not_to eq user2.name
     end
 
     it "creates user with post" do
       expect do
-        FactoryGirl.create(:user, :with_posts, name: 'John')
+        TestProf::FactoryBot.create(:user, :with_posts, name: 'John')
       end.to change(Post, :count).by(2)
     end
   end
@@ -43,16 +43,16 @@ describe "User" do
 end
 
 describe "Post" do
-  context "created by factory_girl" do
-    let(:user) { FactoryGirl.create(:user) }
+  context "created by factory_bot" do
+    let(:user) { TestProf::FactoryBot.create(:user) }
 
     it "creates posts with users" do
-      expect { FactoryGirl.create_pair(:post) }.to change(User, :count).by(2)
+      expect { TestProf::FactoryBot.create_pair(:post) }.to change(User, :count).by(2)
     end
 
     it "creates post with defined user" do
       user
-      expect { FactoryGirl.create(:post, user: user) }
+      expect { TestProf::FactoryBot.create(:post, user: user) }
         .not_to change(User, :count)
     end
   end

--- a/spec/integrations/fixtures/rspec/factory_prof_no_factory_bot_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_prof_no_factory_bot_fixture.rb
@@ -2,13 +2,14 @@
 
 $LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 
-$LOAD_PATH.delete_if { |p| p =~ /factory_girl/ }
+$LOAD_PATH.delete_if { |p| (p =~ /factory_girl/) || (p =~ /factory_bot/) }
 
 require "test-prof"
 
-context "when no factory_girl installed" do
+context "when no factory_bot installed" do
   it "do nothing" do
     expect { FactoryGirl.create(:user) }.to raise_error(NameError)
+    expect { FactoryBot.create(:user) }.to raise_error(NameError)
     expect(true).to eq true
   end
 end

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -6,7 +6,7 @@ require_relative "../../../support/transactional_context"
 require "test_prof/recipes/rspec/let_it_be"
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include TestProf::FactoryBot::Syntax::Methods
 end
 
 describe "User", :transactional do

--- a/spec/support/ar_models.rb
+++ b/spec/support/ar_models.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 require "active_record"
-require "factory_girl"
 require "fabrication"
+require "test_prof"
+require "test_prof/factory_bot"
 
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
 
@@ -35,13 +36,13 @@ class Post < ActiveRecord::Base
   belongs_to :user
 end
 
-FactoryGirl.define do
+TestProf::FactoryBot.define do
   factory :user do
     sequence(:name) { |n| "John #{n}" }
 
     trait :with_posts do
       after(:create) do
-        FactoryGirl.create_pair(:post)
+        TestProf::FactoryBot.create_pair(:post)
       end
     end
   end

--- a/spec/test_prof/any_fixture_spec.rb
+++ b/spec/test_prof/any_fixture_spec.rb
@@ -28,21 +28,21 @@ describe TestProf::AnyFixture, :transactional do
     it "tracks AR queries and delete affected tables" do
       # add a record outside of any fixture to check
       # that we delete all records from the tables
-      FactoryGirl.create(:user)
+      TestProf::FactoryBot.create(:user)
 
       expect do
-        subject.register(:user) { FactoryGirl.create(:user) }
+        subject.register(:user) { TestProf::FactoryBot.create(:user) }
       end.to change(User, :count).by(1)
 
       expect do
-        subject.register(:post) { FactoryGirl.create(:post) }
+        subject.register(:post) { TestProf::FactoryBot.create(:post) }
       end.to change(User, :count).by(1)
                                  .and change(Post, :count).by(1)
 
       subject.clean
 
       # Try to re-register user - should have no effect
-      subject.register(:user) { FactoryGirl.create(:user) }
+      subject.register(:user) { TestProf::FactoryBot.create(:user) }
 
       expect(User.count).to eq 0
       expect(Post.count).to eq 0
@@ -52,13 +52,13 @@ describe TestProf::AnyFixture, :transactional do
   describe "#reset" do
     it "delete affected tables and reset cache" do
       expect do
-        subject.register(:user) { FactoryGirl.create(:user) }
+        subject.register(:user) { TestProf::FactoryBot.create(:user) }
       end.to change(User, :count).by(1)
 
       subject.reset
       expect(User.count).to eq 0
 
-      subject.register(:user) { FactoryGirl.create(:user) }
+      subject.register(:user) { TestProf::FactoryBot.create(:user) }
 
       expect(User.count).to eq 1
     end

--- a/spec/test_prof/factory_doctor_spec.rb
+++ b/spec/test_prof/factory_doctor_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-# Init FactoryDoctor and patch FactoryGirl
+# Init FactoryDoctor and patch TestProf::FactoryBot
 TestProf::FactoryDoctor.init
 
 describe TestProf::FactoryDoctor, :transactional do
@@ -16,7 +16,7 @@ describe TestProf::FactoryDoctor, :transactional do
     subject(:result) { described_class.result }
 
     it "is not bad when nothing created" do
-      FactoryGirl.build_stubbed(:user)
+      TestProf::FactoryBot.build_stubbed(:user)
       User.first
       expect(result).not_to be_bad
       expect(result.count).to eq 0
@@ -25,14 +25,14 @@ describe TestProf::FactoryDoctor, :transactional do
     end
 
     it "detects one useless object" do
-      FactoryGirl.create(:user)
+      TestProf::FactoryBot.create(:user)
       expect(result).to be_bad
       expect(result.count).to eq 1
       expect(result.time).to be > 0
     end
 
     it "detects not useless object when select" do
-      user = FactoryGirl.create(:user)
+      user = TestProf::FactoryBot.create(:user)
       user.reload
 
       expect(result).not_to be_bad
@@ -42,7 +42,7 @@ describe TestProf::FactoryDoctor, :transactional do
     end
 
     it "detects not useless object when update" do
-      user = FactoryGirl.create(:user)
+      user = TestProf::FactoryBot.create(:user)
       user.update!(name: 'Phil')
 
       expect(result).not_to be_bad
@@ -52,7 +52,7 @@ describe TestProf::FactoryDoctor, :transactional do
     end
 
     it "detects many objects" do
-      FactoryGirl.create_pair(:user)
+      TestProf::FactoryBot.create_pair(:user)
 
       expect(result).to be_bad
       expect(result.count).to eq 2
@@ -62,7 +62,7 @@ describe TestProf::FactoryDoctor, :transactional do
     describe "#ignore" do
       it "does not track create" do
         described_class.ignore do
-          FactoryGirl.create(:user)
+          TestProf::FactoryBot.create(:user)
         end
 
         expect(result).not_to be_bad
@@ -71,7 +71,7 @@ describe TestProf::FactoryDoctor, :transactional do
       end
 
       it "does not track queries" do
-        user = FactoryGirl.create(:user)
+        user = TestProf::FactoryBot.create(:user)
 
         described_class.ignore { user.reload }
 

--- a/spec/test_prof/factory_prof_spec.rb
+++ b/spec/test_prof/factory_prof_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-# Init FactoryProf and patch FactoryGirl, Fabrication
+# Init FactoryProf and patch TestProf::FactoryBot, Fabrication
 TestProf::FactoryProf.init
 TestProf::FactoryProf.configure do |config|
   # turn on stacks collection
@@ -19,24 +19,24 @@ describe TestProf::FactoryProf, :transactional do
   describe "#result" do
     subject(:result) { described_class.result }
 
-    context "when factory_girl used" do
+    context "when factory_bot used" do
       it "has no stacks when no data created" do
-        FactoryGirl.build_stubbed(:user)
+        TestProf::FactoryBot.build_stubbed(:user)
         User.first
         expect(result.stacks.size).to eq 0
       end
 
       it "contains simple stack" do
-        FactoryGirl.create(:user)
+        TestProf::FactoryBot.create(:user)
         expect(result.stacks.size).to eq 1
         expect(result.total).to eq 1
         expect(result.stacks.first).to eq([:user])
       end
 
       it "contains many stacks" do
-        FactoryGirl.create_pair(:user)
-        FactoryGirl.create(:post)
-        FactoryGirl.create(:user, :with_posts)
+        TestProf::FactoryBot.create_pair(:user)
+        TestProf::FactoryBot.create(:post)
+        TestProf::FactoryBot.create(:user, :with_posts)
 
         expect(result.stacks.size).to eq 4
         expect(result.total).to eq 9


### PR DESCRIPTION
Fixes #45 

Wrap-up:
* Each travis build now has two gemfiles - one with `factory_bot` and another one with `factory_girl`
* Introduced `TestProf::FactoryBot` constant, which replaces `FactoryGirl` and points either to `FactoryBot` or `FactoryGirl`, if one of them is installed
* Error message in `test-prof/lib/test_prof/event_prof/custom_events/factory_create.rb` file replaced with more generic one