### PR TITLE
Сorrect travis build matrix syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ matrix:
     - rvm: jruby-9.1.0.0
       gemfile: gemfiles/jruby.gemfile
     - rvm: 2.4.1
-      gemfile:
-        - Gemfile
-        - gemfiles/default_factory_girl.gemfile
+      gemfile: Gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/default_factory_girl.gemfile
     - rvm: 2.4.1
       gemfile: gemfiles/rspec32.gemfile
     - rvm: 2.4.1


### PR DESCRIPTION
Recently I  have discovered, that 2 of 9 jobs are not actually run by Travis due to a syntax error in `.travis.yml`. However, somehow, those jobs are always marked as "successful" and errors seen only after researching the job log.  This syntax was initially found in [Travis docs](https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix), but apparently, it doesn't get parsed correctly in some scenarios.