### PR TITLE
Add rubocop-md

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,12 @@
+require:
+  - rubocop-md
+
 AllCops:
   Include:
     - 'lib/**/*.rb'
     - 'lib/**/*.rake'
     - 'spec/**/*.rb'
+    - 'guides/*.md'
   Exclude:
     - 'bin/**/*'
     - 'spec/dummy/**/*'
@@ -10,6 +14,7 @@ AllCops:
     - 'tmp/**/*'
     - 'Rakefile'
     - 'Gemfile'
+    - 'README.md'
     - '*.gemspec'
   DisplayCopNames: true
   StyleGuideCopsOnly: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## 0.4.3
 
-- [#46](https://github.com/palkan/test-prof/pull/46) Support FactoryBot, which is [former FactoryGirl](https://github.com/thoughtbot/factory_bot/pull/1051), 
+- [#46](https://github.com/palkan/test-prof/pull/46) Support FactoryBot, which is [former FactoryGirl](https://github.com/thoughtbot/factory_bot/pull/1051),
   while maintaining compatibility with latter. ([@Shkrt][])
 
 ## 0.4.2

--- a/guides/.rubocop.yml
+++ b/guides/.rubocop.yml
@@ -1,0 +1,1 @@
+# Leave it blank to use default Rubocop config in guides

--- a/guides/any_fixture.md
+++ b/guides/any_fixture.md
@@ -10,7 +10,7 @@ Consider an example:
 
 ```ruby
 # The best way to use AnyFixture is through RSpec shared contexts
-RSpec.shared_context "account", account: true do
+RSpec.shared_context 'account', account: true do
   # You should call AnyFixture outside of transaction to re-use the same
   # data between examples
   before(:all) do
@@ -30,22 +30,21 @@ RSpec.shared_context "account", account: true do
 
   let(:account) { @account }
 
-  # Or hard-reload object if there is chance of in-place modification within tests
+  # Or hard-reload object if there is chance of in-place modification
   let(:account) { Account.find(@account.id) }
 end
-
 
 # Then in your tests
 
 # Active this fixture using a tag
 describe UsersController, :account do
-  ...
+  # ...
 end
 
 # This test also uses the same account record,
 # no double-creation
 describe PostsController, :account do
-  ...
+  # ...
 end
 ```
 
@@ -54,7 +53,7 @@ end
 In your `spec_helper.rb`:
 
 ```ruby
-require "test_prof/recipes/rspec/any_fixture"
+require 'test_prof/recipes/rspec/any_fixture'
 ```
 
 Now you can use `TestProf::AnyFixture` in your tests.
@@ -79,7 +78,7 @@ end
 And the shared contexts:
 
 ```ruby
-RSpec.shared_context "author" do
+RSpec.shared_context 'author' do
   before(:all) do
     @author = TestProf::AnyFixture.register(:author) do
       FactoryGirl.create(:account)
@@ -89,7 +88,7 @@ RSpec.shared_context "author" do
   let(:author) { @author }
 end
 
-RSpec.shared_context "article" do
+RSpec.shared_context 'article' do
   before(:all) do
     # outside of AnyFixture, we don't know about its dependent tables
     author = FactoryGirl.create(:author)
@@ -107,9 +106,9 @@ Then in some example:
 
 ```ruby
 # This one adds only the 'articles' table to the list of affected tables
-include_context "article"
+include_context 'article'
 # And this one adds the 'authors' table
-include_context "author"
+include_context 'author'
 ```
 
 Now we have the following affected tables list: `['articles', 'authors']`. At the end of the suite, the 'authors' table is cleaned first which leads to a foreign-key violation error.

--- a/guides/before_all.md
+++ b/guides/before_all.md
@@ -27,10 +27,10 @@ Or you can try `before(:all)`:
 describe BeatleWeightedSearchQuery do
   before(:all) do
     @paul = create(:beatle, name: 'Paul')
-    ...
+    # ...
   end
 
-  ...
+  # ...
 end
 ```
 
@@ -43,10 +43,10 @@ And that's how `before_all` works:
 describe BeatleWeightedSearchQuery do
   before_all do
     @paul = create(:beatle, name: 'Paul')
-    ...
+    # ...
   end
 
-  ...
+  # ...
 end
 ```
 
@@ -57,7 +57,7 @@ That's all!
 In your `spec_helper.rb`:
 
 ```ruby
-require "test_prof/recipes/rspec/before_all"
+require 'test_prof/recipes/rspec/before_all'
 ```
 
 ## Caveats
@@ -72,13 +72,13 @@ end
 
 let(:user) { @user }
 
-it "when user is admin" do
+it 'when user is admin' do
   # we modified our object in-place!
   user.update!(role: 1)
   expect(user).to be_admin
 end
 
-it "when user is regular" do
+it 'when user is regular' do
   # now @user's state depends on the order of specs!
   expect(user).not_to be_admin
 end

--- a/guides/factory_default.md
+++ b/guides/factory_default.md
@@ -31,15 +31,15 @@ end
 And we want to test the `Task` model:
 
 ```ruby
-describe "PATCH #update" do
+describe 'PATCH #update' do
   let(:task) { create(:task) }
 
-  it "works" do
+  it 'works' do
     patch :update, id: task.id, task: { completed: 't' }
     expect(response).to be_success
   end
 
-  ...
+  # ...
 end
 ```
 
@@ -50,12 +50,12 @@ And it breaks our logic (every object should belong to the same account).
 Typical workaround:
 
 ```ruby
-describe "PATCH #update" do
+describe 'PATCH #update' do
   let(:account) { create(:account) }
   let(:project) { create(:project, account: account) }
   let(:task) { create(:task, project: project, account: account) }
 
-  it "works" do
+  it 'works' do
     patch :update, id: task.id, task: { completed: 't' }
     expect(response).to be_success
   end
@@ -67,7 +67,7 @@ That works. And there are some cons: it's a little bit verbose and error-prone (
 Here is how we can deal with it using FactoryDefault:
 
 ```ruby
-describe "PATCH #update" do
+describe 'PATCH #update' do
   let(:account) { create_default(:account) }
   let(:project) { create_default(:project) }
   let(:task) { create(:task) }
@@ -75,9 +75,9 @@ describe "PATCH #update" do
   # and if we need more projects, users, tasks with the same parent record,
   # we just write
   let(:another_project) { create(:project) } # uses the same account
-  let(:another_task) { create(:task) } # uses the same account and the first project
+  let(:another_task) { create(:task) } # uses the same account
 
-  it "works" do
+  it 'works' do
     patch :update, id: task.id, task: { completed: 't' }
     expect(response).to be_success
   end
@@ -91,7 +91,7 @@ end
 In your `spec_helper.rb`:
 
 ```ruby
-require "test_prof/recipes/rspec/factory_default"
+require 'test_prof/recipes/rspec/factory_default'
 ```
 
 This adds two new methods to FactoryBot:

--- a/guides/factory_doctor.md
+++ b/guides/factory_doctor.md
@@ -3,7 +3,7 @@
 One common bad pattern that slows our tests down is unnecessary database manipulation. Consider a _bad_ example:
 
 ```ruby
-it "validates name presence" do
+it 'validates name presence' do
   user = create(:user)
   user.name = ''
   expect(user).not_to be_valid
@@ -13,7 +13,7 @@ end
 Here we create a new user record, run all callbacks and validations and save it to the database. We don't need all these! Here is a _good_ example:
 
 ```ruby
-it "validates name presence" do
+it 'validates name presence' do
   user = build_stubbed(:user)
   user.name = ''
   expect(user).not_to be_valid
@@ -46,7 +46,7 @@ You can also tell FactoryDoctor to ignore specific examples/groups. Just add the
 
 ```ruby
 # won't be reported as offense
-it "is ignored", :fd_ignore do
+it 'is ignored', :fd_ignore do
   user = create(:user)
   user.name = ''
   expect(user).not_to be_valid
@@ -94,7 +94,7 @@ Just use `fd_ignore` inside your example:
 
 ```ruby
 # won't be reported as offense
-it "is ignored" do
+it 'is ignored' do
   fd_ignore
 
   @user.name = ''

--- a/guides/factory_prof.md
+++ b/guides/factory_prof.md
@@ -72,7 +72,7 @@ end
 create(:comment) #=> creates 5 records
 
 # And the corresponding stack is:
-[:comment, :answer, :question, :author, :author, :author]
+# [:comment, :answer, :question, :author, :author, :author]
 ```
 
 The wider column the more often this stack appears.

--- a/guides/let_it_be.md
+++ b/guides/let_it_be.md
@@ -25,12 +25,12 @@ We already have [`before_all`](https://github.com/palkan/test-prof/tree/master/g
 describe BeatleWeightedSearchQuery do
   before_all do
     @paul = create(:beatle, name: 'Paul')
-    ...
+    # ...
   end
 
   specify { expect(subject.call('joh')).to contain_exactly(@john) }
 
-  ...
+  # ...
 end
 ```
 
@@ -60,7 +60,7 @@ That's it! Just replace `let!` with `let_it_be`. That's equal to the `before_all
 In your `spec_helper.rb`:
 
 ```ruby
-require "test_prof/recipes/rspec/let_it_be"
+require 'test_prof/recipes/rspec/let_it_be'
 ```
 
 In your tests:
@@ -69,7 +69,7 @@ In your tests:
 describe MySuperDryService do
   let_it_be(:user) { create(:user) }
 
-  ...
+  # ...
 end
 ```
 

--- a/guides/rspec_stamp.md
+++ b/guides/rspec_stamp.md
@@ -17,7 +17,7 @@ Step 0. Make sure that all your tests pass.
 Step 1. Create a shared context to conditionally turn on `inline!` mode:
 
 ```ruby
-shared_context "sidekiq:inline", sidekiq: :inline do
+shared_context 'sidekiq:inline', sidekiq: :inline do
   around(:each) { |ex| Sidekiq::Testing.inline!(&ex) }
 end
 ```

--- a/guides/rubocop.md
+++ b/guides/rubocop.md
@@ -36,7 +36,7 @@ it { is_expected.to have_header('X-TOTAL-PAGES', 10) }
 it { is_expected.to have_header('X-NEXT-PAGE', 2) }
 
 # good
-it "returns the second page", :aggregate_failures do
+it 'returns the second page', :aggregate_failures do
   is_expected.to be_success
   is_expected.to have_header('X-TOTAL-PAGES', 10)
   is_expected.to have_header('X-NEXT-PAGE', 2)

--- a/guides/ruby_prof.md
+++ b/guides/ruby_prof.md
@@ -33,8 +33,8 @@ TestProf::RubyProf.run
 TestProf provides a built-in shared context for RSpec to profile examples individually:
 
 ```ruby
-it "is doing heavy stuff", :rprof do
-  ...
+it 'is doing heavy stuff', :rprof do
+  # ...
 end
 ```
 

--- a/guides/stack_prof.md
+++ b/guides/stack_prof.md
@@ -33,8 +33,8 @@ TestProf::StackProf.run
 TestProf provides a built-in shared context for RSpec to profile examples individually:
 
 ```ruby
-it "is doing heavy stuff", :sprof do
-  ...
+it 'is doing heavy stuff', :sprof do
+  # ...
 end
 ```
 

--- a/guides/tag_prof.md
+++ b/guides/tag_prof.md
@@ -40,8 +40,7 @@ That's the quick workaround:
 
 ```ruby
 RSpec.configure do |config|
-
-  ...
+  # ...
   config.define_derived_metadata(file_path: %r{/spec/}) do |metadata|
     # do not overwrite type if it's already set
     next if metadata.key?(:type)

--- a/guides/tests_sampling.md
+++ b/guides/tests_sampling.md
@@ -9,10 +9,10 @@ Require the corresponding patch:
 
 ```ruby
 # For RSpec in your spec_helper.rb
-require "test_prof/recipes/rspec/sample"
+require 'test_prof/recipes/rspec/sample'
 
 # For Minitest in your test_helper.rb
-require "test_prof/recipes/minitest/sample"
+require 'test_prof/recipes/minitest/sample'
 ```
 
 And then just add `SAMPLE` env variable with the number of example groups (or suites) you want to run:

--- a/test-prof.gemspec
+++ b/test-prof.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "minitest", "~> 5.9"
   spec.add_development_dependency "rubocop", "~> 0.50"
+  spec.add_development_dependency "rubocop-md", ">= 0.1.1"
 end


### PR DESCRIPTION
Make style in guides consistent with Ruby style guide using [rubocop-md](https://github.com/palkan/rubocop-md).