### PR TITLE
fix RubyProf Printers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix RubyProf Printers Support ([@rabotyaga][])
+
 ## 0.4.6
 
 - Upgrade RSpec/AggregateFailures to RuboCop 0.52.0. ([@palkan][])

--- a/lib/test_prof.rb
+++ b/lib/test_prof.rb
@@ -73,7 +73,7 @@ module TestProf
 
     # Return a path to store artifact
     def artifact_path(filename)
-      FileUtils.mkdir_p(config.output_dir)
+      create_artifact_dir
 
       with_timestamps(
         ::File.join(
@@ -81,6 +81,10 @@ module TestProf
           filename
         )
       )
+    end
+
+    def create_artifact_dir
+      FileUtils.mkdir_p(config.output_dir)[0]
     end
 
     private

--- a/lib/test_prof/ruby_prof.rb
+++ b/lib/test_prof/ruby_prof.rb
@@ -37,13 +37,14 @@ module TestProf
 
       PRINTERS = {
         'flat' => 'FlatPrinter',
-        'flat_wln' => 'FlatWithLineNumbers',
+        'flat_wln' => 'FlatPrinterWithLineNumbers',
         'graph' => 'GraphPrinter',
         'graph_html' => 'GraphHtmlPrinter',
         'dot' => 'DotPrinter',
         '.' => 'DotPrinter',
         'call_stack' => 'CallStackPrinter',
-        'call_tree' => 'CallTreePrinter'
+        'call_tree' => 'CallTreePrinter',
+        'multi' => 'MultiPrinter'
       }.freeze
 
       # Mapping from printer to report file extension
@@ -52,9 +53,10 @@ module TestProf
         'graph_html' => 'html',
         'dot' => 'dot',
         '.' => 'dot',
-        'call_stack' => 'html',
-        'call_tree' => 'dat'
+        'call_stack' => 'html'
       }.freeze
+
+      LOGFILE_PREFIX = "ruby-prof-report".freeze
 
       attr_accessor :printer, :mode, :min_percent,
                     :include_threads, :eliminate_methods
@@ -107,10 +109,20 @@ module TestProf
           config.eliminate_methods?
 
         printer_type, printer_class = config.resolve_printer
-        path = build_path name, printer_type
 
-        File.open(path, 'w') do |f|
-          printer_class.new(result).print(f, min_percent: config.min_percent)
+        if %w(call_tree multi).include?(printer_type)
+          path = TestProf.create_artifact_dir
+          printer_class.new(result).print(
+              path: path,
+              profile: "#{RubyProf::Configuration::LOGFILE_PREFIX}-#{printer_type}-#{config.mode}-#{name}",
+              min_percent: config.min_percent
+          )
+        else
+          path = build_path name, printer_type
+          File.open(path, 'w') do |f|
+            printer_class.new(result).print(f, min_percent: config.min_percent)
+          end
+
         end
 
         log :info, "RubyProf report generated: #{path}"
@@ -120,7 +132,7 @@ module TestProf
 
       def build_path(name, printer)
         TestProf.artifact_path(
-          "ruby-prof-report-#{printer}-#{config.mode}-#{name}" \
+          "#{RubyProf::Configuration::LOGFILE_PREFIX}-#{printer}-#{config.mode}-#{name}" \
           ".#{RubyProf::Configuration::PRINTER_EXTENSTION.fetch(printer, 'txt')}"
         )
       end

--- a/lib/test_prof/ruby_prof.rb
+++ b/lib/test_prof/ruby_prof.rb
@@ -110,12 +110,13 @@ module TestProf
 
         printer_type, printer_class = config.resolve_printer
 
-        if %w(call_tree multi).include?(printer_type)
+        if %w[call_tree multi].include?(printer_type)
           path = TestProf.create_artifact_dir
           printer_class.new(result).print(
-              path: path,
-              profile: "#{RubyProf::Configuration::LOGFILE_PREFIX}-#{printer_type}-#{config.mode}-#{name}",
-              min_percent: config.min_percent
+            path: path,
+            profile: "#{RubyProf::Configuration::LOGFILE_PREFIX}-#{printer_type}-" \
+              "#{config.mode}-#{name}",
+            min_percent: config.min_percent
           )
         else
           path = build_path name, printer_type


### PR DESCRIPTION
fixes support of RubyProf printers:
 - FlatPrinterWithLineNumbers - minor typo fixed
 - CallTreePrinter - needs different arguments
+ added support for MultiPrinter, needs same arguments as CallTreePrinter