### PR TITLE
rspec dissect: default value of 0 for example_finished

### DIFF
--- a/lib/test_prof/rspec_dissect/rspec.rb
+++ b/lib/test_prof/rspec_dissect/rspec.rb
@@ -36,7 +36,7 @@ module TestProf
 
       def example_finished(notification)
         @examples_count += 1
-        @examples_time += notification.example.execution_result.run_time
+        @examples_time += notification.example.execution_result.run_time || 0 
       end
 
       # NOTE: RSpec < 3.4.0 doesn't have example_finished event


### PR DESCRIPTION
Fixes #60 by providing a default value

- [ ] Include tests for this change
- [ ] Add Changelog entry

