### PR TITLE
Skip non-regular examples in AggregateFailures cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master
 
+- [Fix [#75](https://github.com/palkan/test-prof/issues/75)] Fix `RSpec/Aggregate` failures with non-regular examples. ([@palkan][])
+
+Do not take into account `xit`, `pending`, `its`, etc. examples,
+only consider regular `it`, `specify`, `scenario`, `example`.
+
 ## 0.5.0 (2018-04-25)
 
 ### Features

--- a/lib/test_prof/cops/rspec/aggregate_failures.rb
+++ b/lib/test_prof/cops/rspec/aggregate_failures.rb
@@ -27,15 +27,10 @@ module RuboCop
         # From https://github.com/backus/rubocop-rspec/blob/master/lib/rubocop/rspec/language.rb
         GROUP_BLOCKS = %i[
           describe context feature example_group
-          xdescribe xcontext xfeature
-          fdescribe fcontext ffeature
         ].freeze
 
         EXAMPLE_BLOCKS = %i[
-          it specify example scenario its
-          fit fspecify fexample fscenario focus
-          xit xspecify xexample xscenario ski
-          pending
+          it specify example scenario
         ].freeze
 
         class << self

--- a/spec/test_prof/cops/rspec/aggregate_failures_spec.rb
+++ b/spec/test_prof/cops/rspec/aggregate_failures_spec.rb
@@ -53,6 +53,14 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts non-regular one-liners' do
+    inspect_source(['context "request" do',
+                    '  its(:foo) { is_expected.to be_success }',
+                    '  pending { is_expected.to fail }',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'accepts one-liners separated by multiliners' do
     inspect_source(['context "request" do',
                     '  it { is_expected.to be_success }',


### PR DESCRIPTION
Do not take into account `xit`, `pending`, `its` examples,
only  consider regular `it`, `specify`, `scenario`, `example`.

Fixes #75
