### PR TITLE
Add possibility to preserve traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `FactoryDefault.preserve_traits` to preserve traits. ([@mordorreal][])
+
 - Add `EventProf.monitor` to instrument arbitrary methods. ([@palkan][])
 
 Add custom instrumetation easily:

--- a/docs/factory_default.md
+++ b/docs/factory_default.md
@@ -109,3 +109,5 @@ before { FactoryBot.set_factory_default(:user, user) }
 - `FactoryBot#create_default(factory, *args)` – is a shortcut for `create` + `set_factory_default`.
 
 **NOTE**. Defaults are cleaned up after each example.
+
+If you want to preserve traits you can add `FactoryDefault.preserve_traits = true` in your test.

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -9,10 +9,9 @@ module TestProf
   module FactoryDefault
     module DefaultSyntax # :nodoc:
       def create_default(name, *args, &block)
-        set_factory_default(
-          name,
-          TestProf::FactoryBot.create(name, *args, &block)
-        )
+        obj = TestProf::FactoryBot.create(name, *args, &block)
+        return obj if FactoryDefault.preserve_traits
+        set_factory_default(name, obj)
       end
 
       def set_factory_default(name, obj)
@@ -21,6 +20,8 @@ module TestProf
     end
 
     class << self
+      attr_accessor :preserve_traits
+
       def init
         TestProf::FactoryBot::Syntax::Methods.include DefaultSyntax
         TestProf::FactoryBot.extend DefaultSyntax
@@ -29,6 +30,8 @@ module TestProf
         TestProf::FactoryBot::Strategy::Stub.prepend StrategyExt
 
         @store = {}
+        # by default should be false for backward compatibility
+        @preserve_traits = false
       end
 
       def register(name, obj)

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -51,7 +51,7 @@ module TestProf
       end
 
       def reset
-        @store.clear
+        store.clear
       end
 
       private


### PR DESCRIPTION
Now the user can set FactoryDefault.preserve_traits to true and the
factory default will fallback to the default factory behaviour.

Ref: #80

I faced some problem with local test running. Got for every spec:
```
NameError:
  uninitialized constant TestProf::FactoryBot
# ./spec/support/ar_models.rb:42:in `<top (required)>'
# ./spec/spec_helper.rb:12:in `block in <top (required)>'
# ./spec/spec_helper.rb:12:in `each'
# ./spec/spec_helper.rb:12:in `<top (required)>'
# ./spec/test_prof_spec.rb:3:in `<top (required)>'
```
 I'll be very appreciated for your help with this.
