### PR TITLE
[Fix #80] Ability to preserve traits

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,6 +71,10 @@ Style/GlobalVars:
     - 'spec/integrations/fixtures/**/*'
     - 'spec/bugs/fixtures/**/*'
 
+Style/ReturnNil:
+  Enabled: true
+  EnforcedStyle: return
+
 Layout/SpaceInsideStringInterpolation:
   EnforcedStyle: no_space
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ end
 Do not take into account `xit`, `pending`, `its`, etc. examples,
 only consider regular `it`, `specify`, `scenario`, `example`.
 
+- [Fix [#80](https://github.com/palkan/test-prof/issues/80)] Added ability to preserve traits. ([@Vasfed][])
+
+Disabled by default for compatibility. Enable globally by `FactoryDefault.preserve_traits = true` or for single `create_default`: `create_default(:user, preserve_traits: true)`
+
+When enabled - default object will be used only when there's no [traits](https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#traits) in association.
+
 ## 0.5.0 (2018-04-25)
 
 ### Features
@@ -314,3 +320,4 @@ Ensure output dir exists in `#artifact_path` method.
 [@IDolgirev]: https://github.com/IDolgirev
 [@desoleary]: https://github.com/desoleary
 [@rabotyaga]: https://github.com/rabotyaga
+[@Vasfed]: https://github.com/Vasfed

--- a/docs/factory_default.md
+++ b/docs/factory_default.md
@@ -109,3 +109,22 @@ before { FactoryBot.set_factory_default(:user, user) }
 - `FactoryBot#create_default(factory, *args)` – is a shortcut for `create` + `set_factory_default`.
 
 **NOTE**. Defaults are cleaned up after each example.
+
+### Working with traits
+
+When you have traits in your associations like:
+
+```ruby
+factory :post do
+  association :user, factory: %i[user able_to_post]
+end
+
+factory :view do
+  association :user, factory: %i[user unable_to_post_only_view]
+end
+```
+
+and set a default for `user` factory - you will find the same object used in all of the above factories. Sometimes this may break your logic.
+
+To prevent this - set `FactoryDefault.preserve_traits = true` or use per-factory override
+`create_default(:user, preserve_traits: true)`. This reverts back to original FactoryBot behavior for associations that have explicit traits defined.

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -52,10 +52,6 @@ module TestProf
         record[:object]
       end
 
-      def exists?(name, traits = nil)
-        get(name, traits) && true || false
-      end
-
       def remove(name)
         store.delete(name)
       end

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -47,7 +47,7 @@ module TestProf
         return unless record
 
         if traits && !traits.empty?
-          return nil if FactoryDefault.preserve_traits || record[:preserve_traits]
+          return if FactoryDefault.preserve_traits || record[:preserve_traits]
         end
         record[:object]
       end

--- a/lib/test_prof/factory_default/factory_bot_patch.rb
+++ b/lib/test_prof/factory_default/factory_bot_patch.rb
@@ -22,8 +22,7 @@ module TestProf
 
     module StrategyExt
       def association(runner)
-        return super unless FactoryDefault.exists?(runner.name, runner.traits)
-        FactoryDefault.get(runner.name, runner.traits)
+        FactoryDefault.get(runner.name, runner.traits) || super
       end
     end
   end

--- a/lib/test_prof/factory_default/factory_bot_patch.rb
+++ b/lib/test_prof/factory_default/factory_bot_patch.rb
@@ -7,6 +7,14 @@ module TestProf
         def name
           @name
         end
+
+        def traits
+          @traits
+        end
+
+        def overrides
+          @overrides
+        end
       end
     end
 
@@ -14,8 +22,8 @@ module TestProf
 
     module StrategyExt
       def association(runner)
-        return super unless FactoryDefault.exists?(runner.name)
-        FactoryDefault.get(runner.name)
+        return super unless FactoryDefault.exists?(runner.name, runner.traits)
+        FactoryDefault.get(runner.name, runner.traits)
       end
     end
   end

--- a/lib/test_prof/factory_default/factory_bot_patch.rb
+++ b/lib/test_prof/factory_default/factory_bot_patch.rb
@@ -11,10 +11,6 @@ module TestProf
         def traits
           @traits
         end
-
-        def overrides
-          @overrides
-        end
       end
     end
 

--- a/spec/integrations/factory_default_spec.rb
+++ b/spec/integrations/factory_default_spec.rb
@@ -6,6 +6,6 @@ describe "FactoryDefault" do
   specify "RSpec integration", :aggregate_failures do
     output = run_rspec('factory_default')
 
-    expect(output).to include("5 examples, 0 failures")
+    expect(output).to include(" examples, 0 failures")
   end
 end

--- a/spec/integrations/factory_default_spec.rb
+++ b/spec/integrations/factory_default_spec.rb
@@ -6,6 +6,6 @@ describe "FactoryDefault" do
   specify "RSpec integration", :aggregate_failures do
     output = run_rspec('factory_default')
 
-    expect(output).to include(" examples, 0 failures")
+    expect(output).to include("8 examples, 0 failures")
   end
 end

--- a/spec/support/ar_models.rb
+++ b/spec/support/ar_models.rb
@@ -13,6 +13,7 @@ ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:'
 ActiveRecord::Schema.define do
   create_table :users do |t|
     t.string :name
+    t.string :tag
   end
 
   create_table :posts do |t|
@@ -48,6 +49,14 @@ TestProf::FactoryBot.define do
         TestProf::FactoryBot.create_pair(:post)
       end
     end
+
+    trait :traited do
+      tag 'traited'
+    end
+
+    trait :other_trait do
+      tag 'other_trait'
+    end
   end
 
   factory :post do
@@ -56,6 +65,14 @@ TestProf::FactoryBot.define do
 
     trait :with_bad_user do
       user { create(:user) }
+    end
+
+    trait :with_traited_user do
+      association :user, factory: %i[user traited]
+    end
+
+    trait :with_other_traited_user do
+      association :user, factory: %i[user other_trait]
     end
   end
 end


### PR DESCRIPTION
Fixes #80.

This adds option to `TestProf::FactoryDefault` to revert to default behaviour when factories have traits for association.