### PR TITLE
Support its examples in AggregateFailures cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,10 @@ Layout/EmptyLinesAroundArguments:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
+Metrics/ClassLength:
+  Exclude:
+    - 'lib/test_prof/cops/rspec/aggregate_failures.rb'
+
 Metrics/MethodLength:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## master
 
-## 0.7.2 (2018-10-01)
-
-- Add `RSpec/Aggregate` support for non-regular 'its' examples. ([@broels][])
+- Add `RSpec/AggregateFailures` support for non-regular 'its' examples. ([@broels][])
 
 ## 0.7.1 (2018-08-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## 0.7.2 (2018-10-01)
+
+- Add `RSpec/Aggregate` support for non-regular 'its' examples. ([@broels][])
+
 ## 0.7.1 (2018-08-20)
 
 - Add ability to ignore connection configurations in shared connection.([@palkan][])

--- a/docs/rubocop.md
+++ b/docs/rubocop.md
@@ -53,4 +53,6 @@ end
 
 This cop supports auto-correct feature, so you can automatically refactor you legacy tests!
 
+**NOTE**: `its` examples shown here have been deprecated as of RSpec 3, but users of the [rspec-its gem](https://github.com/rspec/rspec-its) can leverage this cop to cut out that dependency.
+
 **NOTE**: auto-correction may break your tests (especially the ones using block-matchers, such as `change`).

--- a/docs/rubocop.md
+++ b/docs/rubocop.md
@@ -40,12 +40,14 @@ Consider an example:
 it { is_expected.to be_success }
 it { is_expected.to have_header('X-TOTAL-PAGES', 10) }
 it { is_expected.to have_header('X-NEXT-PAGE', 2) }
+its(:status) { is_expected.to eq(200) }
 
 # good
 it 'returns the second page', :aggregate_failures do
   is_expected.to be_success
   is_expected.to have_header('X-TOTAL-PAGES', 10)
   is_expected.to have_header('X-NEXT-PAGE', 2)
+  expect(subject.status).to eq(200)
 end
 ```
 

--- a/lib/test_prof/cops/rspec/aggregate_failures.rb
+++ b/lib/test_prof/cops/rspec/aggregate_failures.rb
@@ -30,7 +30,7 @@ module RuboCop
         ].freeze
 
         EXAMPLE_BLOCKS = %i[
-          it specify example scenario
+          it its specify example scenario
         ].freeze
 
         class << self
@@ -134,12 +134,23 @@ module RuboCop
         def header_from(node)
           method, _args, _body = *node
           _receiver, method_name, _object = *method
+          method_name = :it if method_name == :its
           %(#{method_name} "works", :aggregate_failures do)
         end
 
         def body_from(node, base_indent = '')
-          _method, _args, body = *node
-          "#{base_indent}#{indent}#{body.source}"
+          method, _args, body = *node
+
+          if method.method_name == :its
+            attribute = method.arguments.first.value
+            expectation = body.method_name
+            match = body.arguments.first.source
+            body_source = "expect(subject.#{attribute}).#{expectation} #{match}"
+          else
+            body_source = body.source
+          end
+
+          "#{base_indent}#{indent}#{body_source}"
         end
 
         def indent

--- a/lib/test_prof/cops/rspec/aggregate_failures.rb
+++ b/lib/test_prof/cops/rspec/aggregate_failures.rb
@@ -142,13 +142,7 @@ module RuboCop
 
         def body_from(node, base_indent = '')
           method, _args, body = *node
-
-          if method.method_name == :its
-            body_source = body_from_its(method, body)
-          else
-            body_source = body.source
-          end
-
+          body_source = method.method_name == :its ? body_from_its(method, body) : body.source
           "#{base_indent}#{indent}#{body_source}"
         end
 

--- a/spec/test_prof/cops/rspec/aggregate_failures_spec.rb
+++ b/spec/test_prof/cops/rspec/aggregate_failures_spec.rb
@@ -53,7 +53,7 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
     expect(cop.messages.first).to eq('Use :aggregate_failures instead of several one-liners.')
   end
 
-  it 'rejects one-liners with nested context' do
+  it 'accepts one-liners with nested context' do
     inspect_source(['context "request" do',
                     '  it { is_expected.to be_success }',
                     '  it "works" do',

--- a/spec/test_prof/cops/rspec/aggregate_failures_spec.rb
+++ b/spec/test_prof/cops/rspec/aggregate_failures_spec.rb
@@ -29,6 +29,16 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
     expect(cop.messages.first).to eq('Use :aggregate_failures instead of several one-liners.')
   end
 
+  it 'rejects two its one-liners in a row' do
+    inspect_source(['context "request" do',
+                    '  its(:status) { is_expected.to eq 200 }',
+                    '  its(:body) { is_expected.to eq "OK" }',
+                    'end'])
+
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages.first).to eq('Use :aggregate_failures instead of several one-liners.')
+  end
+
   it 'rejects two one-liners when blank lines and non-example blocks' do
     inspect_source(['context "request" do',
                     '  let(:user) { create(:user) } ',
@@ -66,9 +76,16 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts single its one-liner' do
+    inspect_source(['context "request" do',
+                    '  its(:status) { is_expected.to eq 200 }',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'accepts non-regular one-liners' do
     inspect_source(['context "request" do',
-                    '  its(:foo) { is_expected.to be_success }',
+                    '  xit { is_expected.to be_success }',
                     '  pending { is_expected.to fail }',
                     'end'])
     expect(cop.offenses).to be_empty
@@ -122,6 +139,24 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
       )
     end
 
+    it "corrects two its one-liners" do
+      new_source = autocorrect_source(
+        ['context "request" do',
+         '  its(:status) { is_expected.to eq 200 }',
+         '  its(:body) { is_expected.to eq "OK" }',
+         'end']
+      )
+
+      expect(new_source).to eq(
+        ['context "request" do',
+         '  it "works", :aggregate_failures do',
+         '    expect(subject.status).to eq 200',
+         '    expect(subject.body).to eq "OK"',
+         '  end',
+         'end'].join("\n")
+      )
+    end
+
     it 'corrects indented one-liners when blank lines and non-example blocks' do
       new_source = autocorrect_source(
         ['describe "GET #index" do',
@@ -133,6 +168,9 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
          '      ',
          '      ',
          '    it { expect(response.body).to eq "OK" }',
+         '      ',
+         '      ',
+         '    its(:status) { is_expected.to eq 200 }',
          '  end',
          'end']
       )
@@ -145,6 +183,7 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
          '    it "works", :aggregate_failures do',
          '      is_expected.to be_success',
          '      expect(response.body).to eq "OK"',
+         '      expect(subject.status).to eq 200',
          '    end',
          '  end',
          'end'].join("\n")
@@ -163,10 +202,14 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
           '      ',
           '      ',
           '    it { expect(response.body).to eq "OK" }',
+          '      ',
+          '      ',
+          '    its(:status) { is_expected.to eq 200 }',
           '',
           '    context "sub-request", :invalid do',
           '      it { is_expected.not_to be_success }',
           '      it { expect(response.body).to eq "FAILED" }',
+          '      its(:status) { is_expected.to eq 404 }',
           '    end',
           '  end',
           'end'
@@ -182,12 +225,14 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
          '    it "works", :aggregate_failures do',
          '      is_expected.to be_success',
          '      expect(response.body).to eq "OK"',
+         '      expect(subject.status).to eq 200',
          '    end',
          '',
          '    context "sub-request", :invalid do',
          '      it "works", :aggregate_failures do',
          '        is_expected.not_to be_success',
          '        expect(response.body).to eq "FAILED"',
+         '        expect(subject.status).to eq 404',
          '      end',
          '    end',
          '  end',

--- a/spec/test_prof/cops/rspec/aggregate_failures_spec.rb
+++ b/spec/test_prof/cops/rspec/aggregate_failures_spec.rb
@@ -128,7 +128,7 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
                     '  its(:body) { is_expected.to be_json_eql(%({"data":{"status":"OK}})).excluding("id") }',
                     'end'])
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages.first).to eq('Use :aggregate_failures instead of several one-liners.' )
+    expect(cop.messages.first).to eq('Use :aggregate_failures instead of several one-liners.')
   end
 
   describe "#autocorrect" do
@@ -251,7 +251,7 @@ describe RuboCop::Cop::RSpec::AggregateFailures, :config do
       )
     end
 
-    it "corrects its edge cases"  do
+    it "corrects its edge cases" do
       new_source = autocorrect_source(
         [
           'context "request" do',


### PR DESCRIPTION
This adds support back to `RSpec/Aggregate` for non-regular 'its' examples. Initial support was removed in #78 since autocorrections would change 'its' examples to regular 'it' comparisons without explicit reference to the subject. These changes handle 'its' examples specially by injecting the subject, handling all 'its' scenarios outlined in the official [rspec/rspec-its spec](https://github.com/rspec/rspec-its/blob/master/lib/rspec/its.rb).