### PR TITLE
Add percentage and total test time to EventPro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## master
 
+- Add a header with the general information on factories usage [#99](https://github.com/palkan/test-prof/issues/99) ([@szemek][])
+
+- Improve test sampling.([@mkldon][])
+
+ ```bash
+ SAMPLE=10 rake test # runs 10 random test examples
+ SAMPLE_GROUPS=10 rake test # runs 10 random example groups
+ ```
+
+ - Extend Event Prof formatter results that includes the absolute run time and percentage of event time percentage [#100](https://github.com/palkan/test-prof/issues/100) ([@dmagro][])
+
 ## 0.7.2 (2018-10-08)
 
 - Add `RSpec/AggregateFailures` support for non-regular 'its' examples. ([@broels][])
@@ -368,3 +379,4 @@ Ensure output dir exists in `#artifact_path` method.
 [@desoleary]: https://github.com/desoleary
 [@rabotyaga]: https://github.com/rabotyaga
 [@Vasfed]: https://github.com/Vasfed
+[@dmagro]: https://github.com/dmagro

--- a/docs/event_prof.md
+++ b/docs/event_prof.md
@@ -9,22 +9,22 @@ Example output:
 ```sh
 [TEST PROF INFO] EventProf results for sql.active_record
 
-Total time: 00:00.256
+Total time: 00:00.256 of 00:00.512 (50.00%)
 Total events: 1031
 
 Top 5 slowest suites (by time):
 
-AnswersController (./spec/controllers/answers_controller_spec.rb:3) – 00:00.119 (549 / 20)
-QuestionsController (./spec/controllers/questions_controller_spec.rb:3) – 00:00.105 (360 / 18)
-CommentsController (./spec/controllers/comments_controller_spec.rb:3) – 00:00.032 (122 / 4)
+AnswersController (./spec/controllers/answers_controller_spec.rb:3) – 00:00.119 (549 / 20) of 00:00.200 (59.50%)
+QuestionsController (./spec/controllers/questions_controller_spec.rb:3) – 00:00.105 (360 / 18) of 00:00.125 (84.00%)
+CommentsController (./spec/controllers/comments_controller_spec.rb:3) – 00:00.032 (122 / 4) of 00:00.064 (50.00%)
 
 Top 5 slowest tests (by time):
 
-destroys question (./spec/controllers/questions_controller_spec.rb:38) – 00:00.022 (29)
-change comments count (./spec/controllers/comments_controller_spec.rb:7) – 00:00.011 (34)
-change Votes count (./spec/shared_examples/controllers/voted_examples.rb:23) – 00:00.008 (25)
-change Votes count (./spec/shared_examples/controllers/voted_examples.rb:23) – 00:00.008 (32)
-fails (./spec/shared_examples/controllers/invalid_examples.rb:3) – 00:00.007 (34)
+destroys question (./spec/controllers/questions_controller_spec.rb:38) – 00:00.022 (29) of 00:00.064 (34.38%)
+change comments count (./spec/controllers/comments_controller_spec.rb:7) – 00:00.011 (34) of 00:00.022 (50.00%)
+change Votes count (./spec/shared_examples/controllers/voted_examples.rb:23) – 00:00.008 (25) of 00:00.022 (36.36%)
+change Votes count (./spec/shared_examples/controllers/voted_examples.rb:23) – 00:00.008 (32) of 00:00.035 (22.86%)
+fails (./spec/shared_examples/controllers/invalid_examples.rb:3) – 00:00.007 (34) of 00:00.014 (50.00%)
 
 ```
 

--- a/lib/test_prof/event_prof/rspec.rb
+++ b/lib/test_prof/event_prof/rspec.rb
@@ -54,6 +54,7 @@ module TestProf
 
       def report(profiler)
         result = profiler.results
+        time_percentage = time_percentage(profiler.total_time, profiler.absolute_run_time)
 
         msgs = []
 
@@ -61,7 +62,7 @@ module TestProf
           <<~MSG
             EventProf results for #{profiler.event}
 
-            Total time: #{profiler.total_time.duration}
+            Total time: #{profiler.total_time.duration} of #{profiler.absolute_run_time.duration} (#{time_percentage}%)
             Total events: #{profiler.total_count}
 
             Top #{profiler.top_count} slowest suites (by #{profiler.rank_by}):
@@ -71,10 +72,13 @@ module TestProf
         result[:groups].each do |group|
           description = group[:id].top_level_description
           location = group[:id].metadata[:location]
+          time = group[:time]
+          run_time = group[:run_time]
+          time_percentage = time_percentage(time, run_time)
 
           msgs <<
             <<~GROUP
-              #{description.truncate} (#{location}) – #{group[:time].duration} (#{group[:count]} / #{group[:examples]})
+              #{description.truncate} (#{location}) – #{time.duration} (#{group[:count]} / #{group[:examples]}) of #{run_time.duration} (#{time_percentage}%)
             GROUP
         end
 
@@ -84,9 +88,13 @@ module TestProf
           result[:examples].each do |example|
             description = example[:id].description
             location = example[:id].metadata[:location]
+            time = example[:time]
+            run_time = example[:run_time]
+            time_percentage = time_percentage(time, run_time)
+
             msgs <<
               <<~GROUP
-                #{description.truncate} (#{location}) – #{example[:time].duration} (#{example[:count]})
+                #{description.truncate} (#{location}) – #{time.duration} (#{example[:count]}) of #{run_time.duration} (#{time_percentage}%)
               GROUP
           end
         end
@@ -127,6 +135,10 @@ module TestProf
           MSG
 
         log :info, msgs.join
+      end
+
+      def time_percentage(time, total_time)
+        (time / total_time * 100).round(2)
       end
     end
   end

--- a/spec/integrations/event_prof_minitest_spec.rb
+++ b/spec/integrations/event_prof_minitest_spec.rb
@@ -7,23 +7,19 @@ describe 'EventProf' do
     output = run_minitest('event_prof', env: { 'EVENT_PROF' => 'test.event' })
 
     expect(output).to include("EventProf results for test.event")
-    expect(output).to match(/Total time: 59:16\.\d{3}/)
+    expect(output).to match(/Total time: 00:00\.514 of 00:01\.\d{3} \(\d{2}\.\d+%\)/)
     expect(output).to include("Total events: 10")
 
     expect(output).to include("Top 5 slowest suites (by time):")
     expect(output).to include("Top 5 slowest tests (by time):")
 
-    expect(output).to include(
-      "Another something (./event_prof_fixture.rb) – 50:00.000 (3 / 2)\n"\
-      "Something (./event_prof_fixture.rb) – 09:16.100 (7 / 3)"
-    )
+    expect(output).to match(/Something \(\.\/event_prof_fixture\.rb\) – 00:00\.214 \(7 \/ 3\) of 00:00\.7\d{2} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/Another something \(\.\/event_prof_fixture\.rb\) – 00:00\.300 \(3 \/ 2\) of 00:00\.3\d{2} \(\d{2}.\d+%\)/)
 
-    expect(output).to include(
-      "do very long ...nvokes 3 times (./event_prof_fixture.rb:48) – 50:00.000 (3)\n"\
-      "invokes twice (./event_prof_fixture.rb:28) – 06:20.000 (2)\n"\
-      "invokes many times (./event_prof_fixture.rb:34) – 02:16.000 (4)\n"\
-      "invokes once (./event_prof_fixture.rb:23) – 00:40.100 (1)"
-    )
+    expect(output).to match(/do very long ...nvokes 3 times \(\.\/event_prof_fixture\.rb:49\) – 00:00\.300 \(3\) of 00:00\.3\d{2} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/invokes many times \(\.\/event_prof_fixture\.rb:35\) – 00:00\.136 \(4\) of 00:00\.4\d{2} \(\d{2}.\d+%\)/)
+    expect(output).to match(/invokes once \(\.\/event_prof_fixture\.rb:24\) – 00:00\.040 \(1\) of 00:00\.1\d{2} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/invokes twice \(\.\/event_prof_fixture\.rb:29\) – 00:00\.038 \(2\) of 00:00\.2\d{2} \(\d{1,2}.\d+%\)/)
   end
   specify 'Minitest integration with rank by count', :aggregate_failures do
     output = run_minitest(
@@ -32,23 +28,19 @@ describe 'EventProf' do
     )
 
     expect(output).to include("EventProf results for test.event")
-    expect(output).to match(/Total time: 59:16\.\d{3}/)
+    expect(output).to match(/Total time: 00:00\.514 of 00:01\.\d{3} \(\d{2}\.\d+%\)/)
     expect(output).to include("Total events: 10")
 
     expect(output).to include("Top 5 slowest suites (by count):")
     expect(output).to include("Top 5 slowest tests (by count):")
 
-    expect(output).to include(
-      "Something (./event_prof_fixture.rb) – 09:16.100 (7 / 3)\n"\
-      "Another something (./event_prof_fixture.rb) – 50:00.000 (3 / 2)"
-    )
+    expect(output).to match(/Something \(\.\/event_prof_fixture\.rb\) – 00:00\.214 \(7 \/ 3\) of 00:00\.7\d{2} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/Another something \(\.\/event_prof_fixture\.rb\) – 00:00\.300 \(3 \/ 2\) of 00:00\.3\d{2} \(\d{2}.\d+%\)/)
 
-    expect(output).to include(
-      "invokes many times (./event_prof_fixture.rb:34) – 02:16.000 (4)\n"\
-      "do very long ...nvokes 3 times (./event_prof_fixture.rb:48) – 50:00.000 (3)\n"\
-      "invokes twice (./event_prof_fixture.rb:28) – 06:20.000 (2)\n"\
-      "invokes once (./event_prof_fixture.rb:23) – 00:40.100 (1)\n"\
-    )
+    expect(output).to match(/do very long ...nvokes 3 times \(\.\/event_prof_fixture\.rb:49\) – 00:00\.300 \(3\) of 00:00\.3\d{2} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/invokes many times \(\.\/event_prof_fixture\.rb:35\) – 00:00\.136 \(4\) of 00:00\.4\d{2} \(\d{2}.\d+%\)/)
+    expect(output).to match(/invokes once \(\.\/event_prof_fixture\.rb:24\) – 00:00\.040 \(1\) of 00:00\.1\d{2} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/invokes twice \(\.\/event_prof_fixture\.rb:29\) – 00:00\.038 \(2\) of 00:00\.2\d{2} \(\d{1,2}.\d+%\)/)
   end
 
   context 'CustomEvents' do

--- a/spec/integrations/event_prof_spec.rb
+++ b/spec/integrations/event_prof_spec.rb
@@ -7,23 +7,19 @@ describe "EventProf RSpec" do
     output = run_rspec('event_prof', env: { 'EVENT_PROF' => 'test.event' })
 
     expect(output).to include("EventProf results for test.event")
-    expect(output).to match(/Total time: 25:56\.\d{3}/)
+    expect(output).to match(/Total time: 00:00\.359 of 00:01\.\d{3} \(\d{2}\.\d+%\)/)
     expect(output).to include("Total events: 8")
 
     expect(output).to include("Top 5 slowest suites (by time):")
     expect(output).to include("Top 5 slowest tests (by time):")
 
-    expect(output).to include(
-      "Another something (./event_prof_fixture.rb:44) – 16:40.000 (1 / 2)\n"\
-      "Something (./event_prof_fixture.rb:21) – 09:16.100 (7 / 3)"
-    )
+    expect(output).to match(/Something \(\.\/event_prof_fixture\.rb:22\) – 00:00\.214 \(7 \/ 3\) of 00:0\d\.\d{3} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/Another something \(\.\/event_prof_fixture\.rb:45\) – 00:00\.145 \(1 \/ 2\) of 00:00\.2\d{2} \(\d{2}.\d+%\)/)
 
-    expect(output).to include(
-      "do very long (./event_prof_fixture.rb:49) – 16:40.000 (1)\n"\
-      "invokes twice (./event_prof_fixture.rb:27) – 06:20.000 (2)\n"\
-      "invokes many times (./event_prof_fixture.rb:34) – 02:16.000 (4)\n"\
-      "invokes once (./event_prof_fixture.rb:22) – 00:40.100 (1)"
-    )
+    expect(output).to match(/do very long \(\.\/event_prof_fixture\.rb:50\) – 00:00\.145 \(1\) of 00:00\.2\d{2} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/invokes many times \(\.\/event_prof_fixture\.rb:35\) – 00:00\.136 \(4\) of 00:00\.5\d{2} \(\d{2}.\d+%\)/)
+    expect(output).to match(/invokes once \(\.\/event_prof_fixture\.rb:23\) – 00:00\.040 \(1\) of 00:00\.\d{3} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/invokes twice \(\.\/event_prof_fixture\.rb:28\) – 00:00\.038 \(2\) of 00:00\.\d{3} \(\d{1,2}.\d+%\)/)
   end
 
   specify "with rank by count", :aggregate_failures do
@@ -33,34 +29,30 @@ describe "EventProf RSpec" do
     )
 
     expect(output).to include("EventProf results for test.event")
-    expect(output).to match(/Total time: 25:56\.\d{3}/)
+    expect(output).to match(/Total time: 00:00\.359 of 00:01\.\d{3} \(\d{2}\.\d+%\)/)
     expect(output).to include("Total events: 8")
 
     expect(output).to include("Top 5 slowest suites (by count):")
     expect(output).to include("Top 5 slowest tests (by count):")
 
-    expect(output).to include(
-      "Something (./event_prof_fixture.rb:21) – 09:16.100 (7 / 3)\n"\
-      "Another something (./event_prof_fixture.rb:44) – 16:40.000 (1 / 2)"
-    )
+    expect(output).to match(/Something \(\.\/event_prof_fixture\.rb:22\) – 00:00\.214 \(7 \/ 3\) of 00:0\d\.\d{3} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/Another something \(\.\/event_prof_fixture\.rb:45\) – 00:00\.145 \(1 \/ 2\) of 00:00\.2\d{2} \(\d{2}.\d+%\)/)
 
-    expect(output).to include(
-      "invokes many times (./event_prof_fixture.rb:34) – 02:16.000 (4)\n"\
-      "invokes twice (./event_prof_fixture.rb:27) – 06:20.000 (2)\n"\
-      "invokes once (./event_prof_fixture.rb:22) – 00:40.100 (1)\n"\
-      "do very long (./event_prof_fixture.rb:49) – 16:40.000 (1)"
-    )
+    expect(output).to match(/do very long \(\.\/event_prof_fixture\.rb:50\) – 00:00\.145 \(1\) of 00:00\.2\d{2} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/invokes many times \(\.\/event_prof_fixture\.rb:35\) – 00:00\.136 \(4\) of 00:00\.5\d{2} \(\d{2}.\d+%\)/)
+    expect(output).to match(/invokes once \(\.\/event_prof_fixture\.rb:23\) – 00:00\.040 \(1\) of 00:00\.\d{3} \(\d{2}\.\d+%\)/)
+    expect(output).to match(/invokes twice \(\.\/event_prof_fixture\.rb:28\) – 00:00\.038 \(2\) of 00:00\.\d{3} \(\d{1,2}.\d+%\)/)
   end
 
   specify "with multiple events", :aggregate_failures do
     output = run_rspec('event_prof', env: { 'EVENT_PROF' => 'test.event,test.another_event' })
 
     expect(output).to include("EventProf results for test.event")
-    expect(output).to match(/Total time: 25:56\.\d{3}/)
+    expect(output).to match(/Total time: 00:00\.359 of 00:01\.\d{3} \(\d{2}\.\d+%\)/)
     expect(output).to include("Total events: 8")
 
     expect(output).to include("EventProf results for test.another_event")
-    expect(output).to match(/Total time: 24:02\.\d{3}/)
+    expect(output).to match(/Total time: 00:00\.154 of 00:01\.\d{3} \(\d{2}\.\d+%\)/)
     expect(output).to include("Total events: 3")
   end
 

--- a/spec/integrations/fixtures/minitest/event_prof_fixture.rb
+++ b/spec/integrations/fixtures/minitest/event_prof_fixture.rb
@@ -11,6 +11,7 @@ end
 
 module Instrumenter
   def self.notify(_event, time)
+    sleep 0.1
     ActiveSupport::Notifications.publish(
       'test.event',
       0,
@@ -21,21 +22,21 @@ end
 
 describe "Something" do
   it "invokes once" do
-    Instrumenter.notify 'test.event', 40.1
+    Instrumenter.notify 'test.event', 0.0401
     assert true
   end
 
   it "invokes twice" do
-    Instrumenter.notify 'test.event', 140
-    Instrumenter.notify 'test.event', 240
+    Instrumenter.notify 'test.event', 0.014
+    Instrumenter.notify 'test.event', 0.024
     assert true
   end
 
   it "invokes many times" do
-    Instrumenter.notify 'test.event', 14
-    Instrumenter.notify 'test.event', 40
-    Instrumenter.notify 'test.event', 42
-    Instrumenter.notify 'test.event', 40
+    Instrumenter.notify 'test.event', 0.014
+    Instrumenter.notify 'test.event', 0.04
+    Instrumenter.notify 'test.event', 0.042
+    Instrumenter.notify 'test.event', 0.04
     assert true
   end
 end
@@ -46,9 +47,9 @@ describe "Another something" do
   end
 
   it "do very long and invokes 3 times" do
-    Instrumenter.notify 'test.event', 1000
-    Instrumenter.notify 'test.event', 1000
-    Instrumenter.notify 'test.event', 1000
+    Instrumenter.notify 'test.event', 0.1
+    Instrumenter.notify 'test.event', 0.1
+    Instrumenter.notify 'test.event', 0.1
     assert true
   end
 end

--- a/spec/integrations/fixtures/rspec/event_prof_fixture.rb
+++ b/spec/integrations/fixtures/rspec/event_prof_fixture.rb
@@ -10,6 +10,7 @@ end
 
 module Instrumenter
   def self.notify(event = "test.event", time)
+    sleep 0.1
     ActiveSupport::Notifications.publish(
       event,
       0,
@@ -20,23 +21,23 @@ end
 
 describe "Something" do
   it "invokes once" do
-    Instrumenter.notify 'test.event', 40.1
+    Instrumenter.notify 'test.event', 0.0401
     expect(true).to eq true
   end
 
   it "invokes twice" do
-    Instrumenter.notify 'test.event', 140
-    Instrumenter.notify 'test.event', 240
-    Instrumenter.notify 'test.another_event', 110
+    Instrumenter.notify 'test.event', 0.014
+    Instrumenter.notify 'test.event', 0.024
+    Instrumenter.notify 'test.another_event', 0.011
     expect(true).to eq true
   end
 
   it "invokes many times" do
-    Instrumenter.notify 'test.event', 14
-    Instrumenter.notify 'test.event', 40
-    Instrumenter.notify 'test.event', 42
-    Instrumenter.notify 'test.event', 40
-    Instrumenter.notify 'test.another_event', 11
+    Instrumenter.notify 'test.event', 0.014
+    Instrumenter.notify 'test.event', 0.04
+    Instrumenter.notify 'test.event', 0.042
+    Instrumenter.notify 'test.event', 0.04
+    Instrumenter.notify 'test.another_event', 0.011
     expect(true).to eq true
   end
 end
@@ -47,8 +48,8 @@ describe "Another something" do
   end
 
   it "do very long" do
-    Instrumenter.notify 'test.event', 1000
-    Instrumenter.notify 'test.another_event', 1321
+    Instrumenter.notify 'test.event', 0.145
+    Instrumenter.notify 'test.another_event', 0.1321
     expect(true).to eq true
   end
 end

--- a/spec/test_prof/event_prof/profiler_spec.rb
+++ b/spec/test_prof/event_prof/profiler_spec.rb
@@ -18,6 +18,10 @@ describe TestProf::EventProf::Profiler do
   subject { described_class.new(event: "test.event", instrumenter: InstrumenterStub, **options) }
 
   describe "#result" do
+    before(:each) do
+      subject.stub(:take_time).and_return(500)
+    end
+
     let(:results) do
       subject
 
@@ -60,9 +64,9 @@ describe TestProf::EventProf::Profiler do
     it "returns top slow groups and totals" do
       expect(results).to eq(
         groups: [
-          { id: 'C', examples: 2, time: 440, count: 2 },
-          { id: 'B', examples: 2, time: 420, count: 3 },
-          { id: 'A', examples: 1, time: 100, count: 1 }
+          { id: 'C', examples: 2, run_time: 500, time: 440, count: 2 },
+          { id: 'B', examples: 2, run_time: 500, time: 420, count: 3 },
+          { id: 'A', examples: 1, run_time: 500, time: 100, count: 1 }
         ]
       )
       expect(subject.total_time).to eq 960
@@ -75,9 +79,9 @@ describe TestProf::EventProf::Profiler do
       it "returns top groups by event occurances" do
         expect(results).to eq(
           groups: [
-            { id: 'B', examples: 2, time: 420, count: 3 },
-            { id: 'C', examples: 2, time: 440, count: 2 },
-            { id: 'A', examples: 1, time: 100, count: 1 }
+            { id: 'B', examples: 2, run_time: 500, time: 420, count: 3 },
+            { id: 'C', examples: 2, run_time: 500, time: 440, count: 2 },
+            { id: 'A', examples: 1, run_time: 500, time: 100, count: 1 }
           ]
         )
       end
@@ -89,8 +93,8 @@ describe TestProf::EventProf::Profiler do
       it "returns top groups by event occurances" do
         expect(results).to eq(
           groups: [
-            { id: 'C', examples: 2, time: 440, count: 2 },
-            { id: 'B', examples: 2, time: 420, count: 3 }
+            { id: 'C', examples: 2, run_time: 500, time: 440, count: 2 },
+            { id: 'B', examples: 2, run_time: 500, time: 420, count: 3 }
           ]
         )
       end
@@ -102,15 +106,15 @@ describe TestProf::EventProf::Profiler do
       it "returns top groups and examples" do
         expect(results).to eq(
           groups: [
-            { id: 'C', examples: 2, time: 440, count: 2 },
-            { id: 'B', examples: 2, time: 420, count: 3 },
-            { id: 'A', examples: 1, time: 100, count: 1 }
+            { id: 'C', examples: 2, run_time: 500, time: 440, count: 2 },
+            { id: 'B', examples: 2, run_time: 500, time: 420, count: 3 },
+            { id: 'A', examples: 1, run_time: 500, time: 100, count: 1 }
           ],
           examples: [
-            { id: 'C1', time: 440, count: 2 },
-            { id: 'B1', time: 380, count: 2 },
-            { id: 'A1', time: 100, count: 1 },
-            { id: 'B2', time: 40,  count: 1 }
+            { id: 'C1', run_time: 500, time: 440, count: 2 },
+            { id: 'B1', run_time: 500, time: 380, count: 2 },
+            { id: 'A1', run_time: 500, time: 100, count: 1 },
+            { id: 'B2', run_time: 500, time: 40,  count: 1 }
           ]
         )
       end


### PR DESCRIPTION
Added a counter called total_test_time to the `Profiler` class that gets incremented with each example time. This attribute helps the `Profiler`class's caller to know the total test time of all runs. Some other changes are related with the percentage took by the examples. Those changes use the `absolute_run_time` to calculate that percentage and the `EventProfFormatter` and `RSpecListener` methods that involved the reporting were updated. The `run_time` field was added to the group and examples results in order to calculate the same absolute run time for each one of them.

Closes #100 
