### PR TITLE
Added let_it_be aliases

### DIFF
--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -7,7 +7,21 @@ module TestProf
   # Just like `let`, but persist the result for the whole group.
   # NOTE: Experimental and magical, for more control use `before_all`.
   module LetItBe
+    class Configuration
+      def alias_to(name, **default_args)
+        LetItBe.define_let_it_be_alias(name, **default_args)
+      end
+    end
+
     class << self
+      def config
+        @config ||= Configuration.new
+      end
+
+      def configure
+        yield config
+      end
+
       def module_for(group)
         modules[group] ||= begin
           Module.new.tap { |mod| group.prepend(mod) }
@@ -24,6 +38,12 @@ module TestProf
     # We want to use the power of Ruby's unicode support)
     # And we love cats!)
     PREFIX = RUBY_ENGINE == "jruby" ? "@__jruby_is_not_cat_friendly__" : "@😸"
+
+    def self.define_let_it_be_alias(name, **default_args)
+      define_method(name) do |identifier, **options, &blk|
+        let_it_be(identifier, default_args.merge(options), &blk)
+      end
+    end
 
     def let_it_be(identifier, **options, &block)
       initializer = proc do

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -18,6 +18,10 @@ RSpec.configure do |config|
   config.include TestProf::FactoryBot::Syntax::Methods
 end
 
+TestProf::LetItBe.configure do |config|
+  config.alias_to :let_with_refind, refind: true
+end
+
 describe "User", :transactional do
   before(:all) do
     @cache = {}
@@ -125,6 +129,24 @@ describe "User", :transactional do
     end
 
     specify { expect(User.count).to eq 1 }
+  end
+
+  context "with aliased let_it_be used to default refind to true" do
+    let_with_refind(:user) { @user = create(:user) }
+
+    it "should refind" do
+      expect(@user).to eq(user)
+      expect(@user.object_id).not_to eq(user.object_id)
+    end
+  end
+
+  context "with aliased let_it_be used to default refind to true but overridden" do
+    let_with_refind(:user, refind: false) { @user = create(:user) }
+
+    it "should not refind" do
+      expect(@user).to eq(user)
+      expect(@user.object_id).to eq(user.object_id)
+    end
   end
 
   context "without let_it_be" do

--- a/spec/integrations/let_it_be_spec.rb
+++ b/spec/integrations/let_it_be_spec.rb
@@ -6,6 +6,6 @@ describe "LetItBe" do
   specify "it works" do
     output = run_rspec("let_it_be")
 
-    expect(output).to include("18 examples, 0 failures")
+    expect(output).to include("20 examples, 0 failures")
   end
 end


### PR DESCRIPTION
#134

API:

    TestProf::LetItBe.configure do |config|
      config.alias_to :let_it_be_with_refind, refind: true
    end

    describe do
      let_it_be_with_refind(:foo) { Foo.create }

      # refind can still be overridden in the alias
      let_it_be_with_refind(:bar, refind: false) { Bar.create }
    end

<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


<!--
  Otherwise, describe the changes: 

### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

-->

<!--
    Please ensure your PR is ready:

    - Include tests for this change
    - Add Changelog entry
    - Update documentation for this change (if appropriate)
-->
