### PR TITLE
before_all hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## master
 
+- Add global `before_all` hooks. ([@danielwaterworth][], [@palkan][])
+
+  Now you can run additional code before and after every `before_all` transaction
+  begins and rollbacks:
+
+  ```ruby
+  TestProf::BeforeAll.configure do |config|
+    config.before(:begin) do
+      # do something before transaction opens
+    end
+
+    config.after(:rollback) do
+      # do something after transaction closes
+    end
+  end
+  ```
+
 - Add ability to use `let_it_be` aliases with predefined options. ([@danielwaterworth][])
 
   ```ruby

--- a/docs/before_all.md
+++ b/docs/before_all.md
@@ -111,6 +111,28 @@ end
 TestProf::BeforeAll.adapter = MyDBAdapter.new
 ```
 
+## Hooks
+
+*@since v0.9.0*
+
+You can register callbacks to run before/after `before_all` opens and rollbacks a transaction:
+
+```ruby
+TestProf::BeforeAll.configure do |config|
+  config.before(:begin) do
+    # do something before transaction opens
+  end
+  # after(:begin) is also available
+
+  config.after(:rollback) do
+    # do something after transaction closes
+  end
+  # before(:rollback) is also available
+end
+```
+
+See the example in [Discourse](https://github.com/discourse/discourse/blob/4a1755b78092d198680c2fe8f402f236f476e132/spec/rails_helper.rb#L81-L141).
+
 ## Caveats
 
 If you modify objects generated within a `before_all` block in your examples, you maybe have to re-initiate them:

--- a/docs/let_it_be.md
+++ b/docs/let_it_be.md
@@ -96,7 +96,7 @@ let(:user) { User.find(@user.id) }
 
 ## Aliases
 
-*@since v0.8.1*
+*@since v0.9.0*
 
 Naming is hard. Handling edge cases (the ones described above) is also tricky.
 

--- a/lib/test_prof/before_all/adapters/active_record.rb
+++ b/lib/test_prof/before_all/adapters/active_record.rb
@@ -12,7 +12,6 @@ module TestProf
       module ActiveRecord
         class << self
           def begin_transaction
-            lock_thread!
             ::ActiveRecord::Base.connection.begin_transaction(joinable: false)
           end
 
@@ -24,18 +23,18 @@ module TestProf
             end
             ::ActiveRecord::Base.connection.rollback_transaction
           end
-
-          private
-
-          # Make sure ActiveRecord uses locked thread.
-          # It only gets locked in `before` / `setup` hook,
-          # thus using thread in `before_all` (e.g. ActiveJob async adapter)
-          # might lead to leaking connections
-          def lock_thread!
-            return unless ::ActiveRecord::Base.connection.pool.respond_to?(:lock_thread=)
-            ::ActiveRecord::Base.connection.pool.lock_thread = true
-          end
         end
+      end
+    end
+
+    configure do |config|
+      # Make sure ActiveRecord uses locked thread.
+      # It only gets locked in `before` / `setup` hook,
+      # thus using thread in `before_all` (e.g. ActiveJob async adapter)
+      # might lead to leaking connections
+      config.before(:begin) do
+        next unless ::ActiveRecord::Base.connection.pool.respond_to?(:lock_thread=)
+        ::ActiveRecord::Base.connection.pool.lock_thread = true
       end
     end
   end

--- a/spec/integrations/before_all_spec.rb
+++ b/spec/integrations/before_all_spec.rb
@@ -4,25 +4,25 @@ require "spec_helper"
 
 describe "BeforeAll" do
   context "RSpec" do
-    specify "it works" do
+    it "works" do
       output = run_rspec("before_all")
 
       expect(output).to include("11 examples, 0 failures")
     end
 
-    specify "it sets up each before_all block" do
-      output = run_rspec("setup_before_all")
+    specify "global hooks" do
+      output = run_rspec("before_all_hooks")
 
       expect(output).to include("3 examples, 0 failures")
     end
 
-    specify "it works with custom adapter" do
+    specify "custom adapter" do
       output = run_rspec("before_all_custom_adapter")
 
       expect(output).to include("3 examples, 0 failures")
     end
 
-    specify "it works with isolator" do
+    it "works with isolator" do
       output = run_rspec("before_all_isolator", success: false)
 
       expect(output).to include("2 examples, 1 failure")
@@ -32,7 +32,7 @@ describe "BeforeAll" do
   end
 
   context "Minitest" do
-    specify "it works" do
+    specify do
       output = run_minitest("before_all")
 
       expect(output).to include("3 runs, 3 assertions, 0 failures, 0 errors, 0 skips")


### PR DESCRIPTION
Follow-up for #135 

Added after hooks.
Added `:rollback` hooks.

```ruby
TestProf::BeforeAll.configure do |config|
  config.before(:begin) do
    # do something before transaction opens
  end

  config.after(:rollback) do
    # do something after transaction closes
  end
end
```