### PR TITLE
Add column to show total time per factory call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix compatibility of `before_all` with [`isolator`](https://github.com/palkan/isolator) gem to handle correct usages of non-atomic interactions outside DB transactions. ([@Envek][])
 
+- Updates FactoryProf to show the amount of time taken per factory call. ([@tyleriguchi][])
+
 ## 0.10.0 (2019-08-19)
 
 - Use RSpec example ID instead of full description for RubyProf/Stackprof report names. ([@palkan][])
@@ -501,3 +503,4 @@ Fixes [#10](https://github.com/palkan/test-prof/issues/10).
 [@dmagro]: https://github.com/dmagro
 [@danielwaterworth]: https://github.com/danielwaterworth
 [@Envek]: https://github.com/Envek
+[@tyleriguchi]: https://github.com/tyleriguchi

--- a/docs/factory_prof.md
+++ b/docs/factory_prof.md
@@ -12,15 +12,16 @@ Total top-level: 10286
 Total time: 299.5937s
 Total uniq factories: 119
 
- total   top-level   total time   top-level time            name
-  6091        2715    115.7671s         50.2517s            user
-  2142        2098     93.3152s         92.1915s            post
+ total   top-level   total time    time per call      top-level time            name
+  6091        2715    115.7671s          0.0426s            50.2517s            user
+  2142        2098     93.3152s          0.0444s            92.1915s            post
   ...
 ```
 
 It shows both the total number of the factory runs and the number of _top-level_ runs, i.e. not during another factory invocation (e.g. when using associations.)
 
 (**@since v0.9.0**) It also shows the time spent generating records with factories.
+(**@since v0.11.0**) It also shows the amount of time taken per factory call.
 
 **NOTE**: FactoryProf only tracks the database-persisted factories. In case of FactoryGirl/FactoryBot these are the factories provided by using `create` strategy. In case of Fabrication - objects that created using `create` method.
 

--- a/lib/test_prof/factory_prof/printers/simple.rb
+++ b/lib/test_prof/factory_prof/printers/simple.rb
@@ -24,11 +24,13 @@ module TestProf::FactoryProf
                Total time: #{format("%.4f", total_time)}s
                Total uniq factories: #{total_uniq_factories}
 
-                 total   top-level   total time   top-level time                           name
+                 total   top-level     total time      time per call      top-level time               name
             MSG
 
           result.stats.each do |stat|
-            msgs << format("%8d %11d %11.4fs %15.4fs %30s", stat[:total_count], stat[:top_level_count], stat[:total_time], stat[:top_level_time], stat[:name])
+            time_per_call = stat[:total_time] / stat[:total_count]
+
+            msgs << format("%8d %11d %13.4fs %17.4fs %18.4fs %18s", stat[:total_count], stat[:top_level_count], stat[:total_time], time_per_call, stat[:top_level_time], stat[:name])
           end
 
           log :info, msgs.join("\n")

--- a/spec/integrations/factory_prof_spec.rb
+++ b/spec/integrations/factory_prof_spec.rb
@@ -11,7 +11,8 @@ describe "FactoryProf" do
 
       expect(output).to include("Factories usage")
       expect(output).to match(/Total: 26\n\s+Total top-level: 14\n\s+Total time: \d+\.\d{4}s\n\s+Total uniq factories: 2/)
-      expect(output).to match(/total\s+top\-level\s+total time\s+top\-level time\s+name\n\n\s+16\s+8\s+(\d+\.\d{4}s\s+){2}user\n\s+10\s+6\s+\s+(\d+\.\d{4}s\s+){2}post/)
+      expect(output).to match(/total\s+top\-level\s+total time\s+time per call\s+top\-level time\s+name/)
+      expect(output).to match(/\s+16\s+8\s+(\d+\.\d{4}s\s+){3}user\n\s+10\s+6\s+\s+(\d+\.\d{4}s\s+){3}post/)
     end
 
     specify "flamegraph printer" do


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


<!--
  Otherwise, describe the changes: 

### What is the purpose of this pull request?
Add
### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation

-->

### What is the purpose of this pull request?
Make it easier to decide which factories to focus on for test performance.
### What changes did you make? (overview)
Adds an additional column to the output for the simple printer to show how long each factory takes per call.

### Is there anything you'd like reviewers to focus on?
Screenshot of the changed output
<img width="985" alt="Screen Shot 2019-08-25 at 1 59 28 PM" src="https://user-images.githubusercontent.com/5283926/63655726-af09cc00-c740-11e9-8b90-d7f3b8da50ab.png">
