### PR TITLE
Fix AnyFixture DSL incompatibility with Rails 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Fix AnyFixture DSL when using with Rails 6.1+. ([@palkan][])
+
 - Fix loading `let_it_be` without ActiveRecord present. ([@palkan][])
 
 - Fix compatibility of `before_all` with [`isolator`](https://github.com/palkan/isolator) gem to handle correct usages of non-atomic interactions outside DB transactions. ([@Envek][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Fix loading `let_it_be` without ActiveRecord present. ([@palkan][])
+
 - Fix compatibility of `before_all` with [`isolator`](https://github.com/palkan/isolator) gem to handle correct usages of non-atomic interactions outside DB transactions. ([@Envek][])
 
 - Updates FactoryProf to show the amount of time taken per factory call. ([@tyleriguchi][])

--- a/Gemfile
+++ b/Gemfile
@@ -10,13 +10,13 @@ local_gemfile = "Gemfile.local"
 if File.exist?(local_gemfile)
   eval_gemfile(local_gemfile) # rubocop:disable Security/Eval
 else
-  gem "sqlite3", "~> 1.3.6"
-  gem "activerecord", "~> 5.0"
+  gem "sqlite3", "~> 1.4"
+  gem "activerecord", "~> 6.0"
 
   gem "factory_bot", "~> 5.0"
   gem "fabrication"
 
-  gem "sidekiq", "~> 5.2"
+  gem "sidekiq", "~> 6.0"
   gem "timecop", "~> 0.9.1"
 
   gem "pry-byebug"

--- a/docs/any_fixture.md
+++ b/docs/any_fixture.md
@@ -92,8 +92,6 @@ before(:all) { fixture(:account) }
 let(:account) { fixture(:account) }
 ```
 
-**NOTE:** Only work for Ruby 2.4+.
-
 ## `ActiveRecord#refind`
 
 TestProf also provides an extension to _hard-reload_ ActiveRecord objects:

--- a/docs/let_it_be.md
+++ b/docs/let_it_be.md
@@ -55,7 +55,7 @@ That's it! Just replace `let!` with `let_it_be`. That's equal to the `before_all
 
 ## Instructions
 
-In your `spec_helper.rb`:
+In your `rails_helper.rb` or `spec_helper.rb`:
 
 ```ruby
 require "test_prof/recipes/rspec/let_it_be"
@@ -92,6 +92,8 @@ let_it_be(:user, refind: true) { create(:user) }
 before_all { @user = create(:user) }
 let(:user) { User.find(@user.id) }
 ```
+
+**NOTE:** make sure that you require `let_it_be` after `active_record` is loaded (e.g., in `rails_helper.rb` **after** requiring the Rails app); otherwise the `refind` and `reload` modifiers are not activated.
 
 (**@since v0.10.0**) You can also use modifiers with array values, e.g. `create_list`:
 

--- a/gemfiles/activerecord6.gemfile
+++ b/gemfiles/activerecord6.gemfile
@@ -4,7 +4,7 @@ gem 'activerecord', '~> 6.0'
 gem "factory_bot", "~> 5.0"
 gem "fabrication"
 gem "sqlite3", "~> 1.4"
-gem "sidekiq", "~> 4.0"
+gem "sidekiq", "~> 6.0"
 gem "timecop", "~> 0.9.1"
 
 gemspec path: '..'

--- a/lib/test_prof/any_fixture/dsl.rb
+++ b/lib/test_prof/any_fixture/dsl.rb
@@ -4,14 +4,10 @@ module TestProf
   module AnyFixture
     # Adds "global" `fixture` method (through refinement)
     module DSL
-      module Ext # :nodoc:
+      refine Kernel do
         def fixture(id, &block)
           ::TestProf::AnyFixture.register(:"#{id}", &block)
         end
-      end
-
-      refine Kernel do
-        include Ext
       end
     end
   end

--- a/lib/test_prof/any_fixture/dsl.rb
+++ b/lib/test_prof/any_fixture/dsl.rb
@@ -4,7 +4,10 @@ module TestProf
   module AnyFixture
     # Adds "global" `fixture` method (through refinement)
     module DSL
-      refine Kernel do
+      # Refine object, 'cause refining modules (Kernel) is vulnerable to prepend:
+      # - https://bugs.ruby-lang.org/issues/13446
+      # - Rails added `Kernel.prepend` in 6.1: https://github.com/rails/rails/commit/3124007bd674dcdc9c3b5c6b2964dfb7a1a0733c
+      refine ::Object do
         def fixture(id, &block)
           ::TestProf::AnyFixture.register(:"#{id}", &block)
         end

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -127,20 +127,22 @@ module TestProf
   end
 end
 
-require "test_prof/ext/active_record_refind"
-using TestProf::Ext::ActiveRecordRefind
+if defined?(::ActiveRecord)
+  require "test_prof/ext/active_record_refind"
+  using TestProf::Ext::ActiveRecordRefind
 
-TestProf::LetItBe.configure do |config|
-  config.register_modifier :reload do |record, val|
-    next record unless val
-    next record unless record.is_a?(::ActiveRecord::Base)
-    record.reload
-  end
+  TestProf::LetItBe.configure do |config|
+    config.register_modifier :reload do |record, val|
+      next record unless val
+      next record unless record.is_a?(::ActiveRecord::Base)
+      record.reload
+    end
 
-  config.register_modifier :refind do |record, val|
-    next record unless val
-    next record unless record.is_a?(::ActiveRecord::Base)
-    record.refind
+    config.register_modifier :refind do |record, val|
+      next record unless val
+      next record unless record.is_a?(::ActiveRecord::Base)
+      record.refind
+    end
   end
 end
 

--- a/spec/integrations/fixtures/rspec/any_fixture_fixture.rb
+++ b/spec/integrations/fixtures/rspec/any_fixture_fixture.rb
@@ -5,17 +5,8 @@ require_relative "../../../support/ar_models"
 require_relative "../../../support/transactional_context"
 require "test_prof/recipes/rspec/any_fixture"
 
-# Ruby <2.4 cannot refine modules
-begin
-  require "test_prof/any_fixture/dsl"
-  using TestProf::AnyFixture::DSL
-rescue TypeError
-  include(Module.new do
-    def fixture(id, &block)
-      TestProf::AnyFixture.register(id, &block)
-    end
-  end)
-end
+require "test_prof/any_fixture/dsl"
+using TestProf::AnyFixture::DSL
 
 shared_context "user", user: true do
   before(:all) do


### PR DESCRIPTION
Refine Object, 'cause refining modules (Kernel) is vulnerable to prepend:
- Known Ruby bug: https://bugs.ruby-lang.org/issues/13446 (hopefully will be fixed https://github.com/ruby/ruby/pull/2550)
- Rails added `Kernel.prepend` in 6.1: https://github.com/rails/rails/commit/3124007bd674dcdc9c3b5c6b2964dfb7a1a0733c


### Checklist

- [x] I've added a Changelog entry
