### PR TITLE
Fix env variable name for setting reports suffixes

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -36,11 +36,11 @@ For example, let's compare tests load time with and without `bootsnap` using [`s
 
 ```sh
 # Generate first report using `-with-bootsnap` suffix
-$ TEST_STACK_PROF=boot TEST_PROF_NAME=with-bootsnap bundle exec rake
+$ TEST_STACK_PROF=boot TEST_PROF_REPORT=with-bootsnap bundle exec rake
 $ #=> StackProf report generated: tmp/test_prof/stack-prof-report-wall-raw-boot-with-bootsnap.dump
 
 # Assume that you disabled bootsnap and want to generate a new report
-$ TEST_STACK_PROF=boot TEST_PROF_NAME=no-bootsnap bundle exec rake
+$ TEST_STACK_PROF=boot TEST_PROF_REPORT=no-bootsnap bundle exec rake
 $ #=> StackProf report generated: tmp/test_prof/stack-prof-report-wall-raw-boot-no-bootsnap.dump
 ```
 


### PR DESCRIPTION
This PR fixes examples in the [Getting Started](https://test-prof.evilmartians.io/#/getting_started) page of the docs. According to the [sources](https://github.com/palkan/test-prof/blob/cffe3651df3c9b656db009ca8e2a44c92fa1befb/lib/test_prof.rb#L144), `TEST_PROF_REPORT` should be used.
