### PR TITLE
Solve ruby 2.7 deprecation warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: no_comma
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_first_parameter
 
 # See https://github.com/rubocop-hq/rubocop/issues/4222

--- a/lib/test_prof/before_all.rb
+++ b/lib/test_prof/before_all.rb
@@ -72,18 +72,18 @@ module TestProf
       # `rollback` operation:
       #
       #   config.before(:rollback) { ... }
-      def before(type)
+      def before(type, &block)
         validate_hook_type!(type)
-        hooks[type].before << Proc.new
+        hooks[type].before << block if block_given?
       end
 
       # Add `after` hook for `begin` or
       # `rollback` operation:
       #
       #   config.after(:begin) { ... }
-      def after(type)
+      def after(type, &block)
         validate_hook_type!(type)
-        hooks[type].after << Proc.new
+        hooks[type].after << block if block_given?
       end
 
       def run_hooks(type) # :nodoc:

--- a/lib/test_prof/event_prof.rb
+++ b/lib/test_prof/event_prof.rb
@@ -95,8 +95,8 @@ module TestProf
       # Use it to profile arbitrary methods:
       #
       #   TestProf::EventProf.monitor(MyModule, "my_module.call", :call)
-      def monitor(mod, event, *mids)
-        Monitor.call(mod, event, *mids)
+      def monitor(mod, event, *mids, **kwargs)
+        Monitor.call(mod, event, *mids, **kwargs)
       end
     end
   end

--- a/lib/test_prof/event_prof/custom_events.rb
+++ b/lib/test_prof/event_prof/custom_events.rb
@@ -5,9 +5,9 @@ module TestProf
     # Registers and activates custom events (which require patches).
     module CustomEvents
       class << self
-        def register(event)
+        def register(event, &block)
           raise ArgumentError, "Block is required!" unless block_given?
-          registrations[event] = Proc.new
+          registrations[event] = block
         end
 
         def activate_all(events)

--- a/lib/test_prof/event_prof/profiler.rb
+++ b/lib/test_prof/event_prof/profiler.rb
@@ -129,9 +129,9 @@ module TestProf
         end
       end
 
-      def each
+      def each(&block)
         if block_given?
-          @profilers.each(&Proc.new)
+          @profilers.each(&block)
         else
           @profilers.each
         end

--- a/lib/test_prof/recipes/active_record_shared_connection.rb
+++ b/lib/test_prof/recipes/active_record_shared_connection.rb
@@ -14,12 +14,12 @@ module TestProf
         self.connection = nil
       end
 
-      def ignore
+      def ignore(&block)
         raise ArgumentError, "Block is required" unless block_given?
 
         @ignores ||= []
 
-        ignores << Proc.new
+        ignores << block
       end
 
       def ignored?(config)

--- a/lib/test_prof/recipes/minitest/before_all.rb
+++ b/lib/test_prof/recipes/minitest/before_all.rb
@@ -57,8 +57,8 @@ module TestProf
       module ClassMethods
         attr_accessor :before_all_executor
 
-        def before_all
-          self.before_all_executor = Executor.new(&Proc.new)
+        def before_all(&block)
+          self.before_all_executor = Executor.new(&block)
 
           prepend(Module.new do
             def setup

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -87,7 +87,7 @@ module TestProf
 
     def self.define_let_it_be_alias(name, **default_args)
       define_method(name) do |identifier, **options, &blk|
-        let_it_be(identifier, default_args.merge(options), &blk)
+        let_it_be(identifier, **default_args.merge(options), &blk)
       end
     end
 

--- a/lib/test_prof/stack_prof.rb
+++ b/lib/test_prof/stack_prof.rb
@@ -96,9 +96,9 @@ module TestProf
 
         if block_given?
           options[:out] = build_path(name)
-          ::StackProf.run(options) { yield }
+          ::StackProf.run(**options) { yield }
         else
-          ::StackProf.start(options)
+          ::StackProf.start(**options)
         end
         true
       end

--- a/lib/test_prof/utils/sized_ordered_set.rb
+++ b/lib/test_prof/utils/sized_ordered_set.rb
@@ -11,11 +11,11 @@ module TestProf
 
       include Enumerable
 
-      def initialize(max_size, sort_by: nil)
+      def initialize(max_size, sort_by: nil, &block)
         @max_size = max_size
         @comparator =
           if block_given?
-            Proc.new
+            block
           elsif !sort_by.nil?
             ->(x, y) { x[sort_by] >= y[sort_by] }
           else
@@ -41,9 +41,9 @@ module TestProf
         data.size
       end
 
-      def each
+      def each(&block)
         if block_given?
-          data.each(&Proc.new)
+          data.each(&block)
         else
           data.each
         end


### PR DESCRIPTION
### What is the purpose of this pull request?

To address the deprecation warnings when using ruby 2.7:

More info here: https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/ 

### What changes did you make? (overview)

- Replace the use of `Proc.new` with `block`
```shell
warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```

- Use double splat where necessary to align parameters definition with Ruby 2.7/3.x  

```shell
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

- Rename Rubocop cop name.

### Is there anything you'd like reviewers to focus on?

⚠️ Currently the github `setup-ruby` action does not support ruby 2.7, so I was unable to add that version to the CI workflows, even though I got it tested successfully on my local machine.

More info:
- https://github.com/actions/setup-ruby
- https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
