### PR TITLE
Github CI workflow installs ruby with use-ruby-action

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby
+      uses: eregon/use-ruby-action@master
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7
     - name: Run Markdown linter
       run: |
         gem install mdl
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby
+      uses: eregon/use-ruby-action@master
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7
     - name: Lint Markdown files with RuboCop
       run: |
         gem install bundler
@@ -43,10 +43,10 @@ jobs:
     - name: Install Hunspell
       run: |
         sudo apt-get install hunspell
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby
+      uses: eregon/use-ruby-action@master
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7
     - name: Run Forspell
       run: |
         gem install forspell

--- a/.github/workflows/rspec-jruby.yml
+++ b/.github/workflows/rspec-jruby.yml
@@ -9,18 +9,19 @@ on:
 jobs:
   rspec-jruby:
     runs-on: ubuntu-latest
-    container:
-      image: jruby:9.2.8
-      env:
-        BUNDLE_GEMFILE: gemfiles/jruby.gemfile
+    env:
+      BUNDLE_GEMFILE: gemfiles/jruby.gemfile
+
     steps:
     - uses: actions/checkout@v1
-    - name: Install git
-      run: |
-        apt-get update
-        apt-get install -y --no-install-recommends git
-    - name: Install deps and run RSpec
+    - name: Set up Ruby
+      uses: eregon/use-ruby-action@master
+      with:
+        ruby-version: jruby
+    - name: Install Ruby deps
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
+    - name: Run RSpec
+      run: |
         bundle exec rspec

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5.x", "2.6.x", "2.4.x"]
+        ruby: [2.4, 2.5, 2.6, 2.7]
         gemfile: [
           "gemfiles/railsmaster.gemfile",
           "gemfiles/activerecord6.gemfile",
@@ -21,28 +21,34 @@ jobs:
           "gemfiles/rspec35.gemfile"
         ]
         exclude:
-        - ruby: "2.6.x"
+        - ruby: 2.7
           gemfile: "gemfiles/activerecord42.gemfile"
-        - ruby: "2.6.x"
+        - ruby: 2.7
           gemfile: "gemfiles/rspec35.gemfile"
-        - ruby: "2.6.x"
+        - ruby: 2.7
           gemfile: "gemfiles/default_factory_girl.gemfile"
-        - ruby: "2.5.x"
-          gemfile: "gemfiles/railsmaster.gemfile"
-        - ruby: "2.5.x"
+        - ruby: 2.6
           gemfile: "gemfiles/activerecord42.gemfile"
-        - ruby: "2.5.x"
+        - ruby: 2.6
           gemfile: "gemfiles/rspec35.gemfile"
-        - ruby: "2.5.x"
+        - ruby: 2.6
           gemfile: "gemfiles/default_factory_girl.gemfile"
-        - ruby: "2.4.x"
+        - ruby: 2.5
           gemfile: "gemfiles/railsmaster.gemfile"
-        - ruby: "2.4.x"
+        - ruby: 2.5
+          gemfile: "gemfiles/activerecord42.gemfile"
+        - ruby: 2.5
+          gemfile: "gemfiles/rspec35.gemfile"
+        - ruby: 2.5
+          gemfile: "gemfiles/default_factory_girl.gemfile"
+        - ruby: 2.4
+          gemfile: "gemfiles/railsmaster.gemfile"
+        - ruby: 2.4
           gemfile: "gemfiles/activerecord6.gemfile"
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: eregon/use-ruby-action@master
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install system deps

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby
+      uses: eregon/use-ruby-action@master
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7
     - name: Lint Ruby code with RuboCop
       run: |
         gem install bundler

--- a/test-prof.gemspec
+++ b/test-prof.gemspec
@@ -40,5 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "isolator", "~> 0.6"
   spec.add_development_dependency "minitest", "~> 5.9"
-  spec.add_development_dependency "rubocop", "~> 0.72.0"
+  spec.add_development_dependency "rubocop", "~> 0.77.0"
 end


### PR DESCRIPTION
### What is the purpose of this pull request?

The default github action to install ruby (`actions/setup-ruby@v1`) doesn't not have support for the most recent versions of ruby. The `use-ruby-action` (https://github.com/eregon/use-ruby-action) seems to be a good alternative for it.

### What changes did you make? (overview)

Changed the github workflows to make use of `use-ruby-action` instead of  `setup-ruby` action to install ruby.

Also:
- Ensure the `Rubocop` version (which is a development dependency) is updated to be compliant with the format of the `.rubocop.yml`. Locally I was getting the following warning:

```
Warning: unrecognized cop Layout/ParameterAlignment found in .rubocop.yml
```

which was updated in https://github.com/palkan/test-prof/pull/168 since CI was failing the `Rubocop` check.


