### PR TITLE
Tell RSpec to require spec_helper

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/spec/bugs/rspec_detection_false_positive_spec.rb
+++ b/spec/bugs/rspec_detection_false_positive_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 # https://github.com/palkan/test-prof/issues/8
 describe "RSpec false positive detection", type: :integration do
   specify do

--- a/spec/bugs/rspec_dissect_pending_spec.rb
+++ b/spec/bugs/rspec_dissect_pending_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 # https://github.com/palkan/test-prof/issues/60
 describe "RSpecDissect with pending examples", type: :integration do
   specify do

--- a/spec/bugs/time_patch_handling_spec.rb
+++ b/spec/bugs/time_patch_handling_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 # https://github.com/palkan/test-prof/issues/10
 describe "Time.now patching handling (e.g. Timecop)", type: :integration do
   specify "works with ad-hoc patch" do

--- a/spec/integrations/any_fixture_spec.rb
+++ b/spec/integrations/any_fixture_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "AnyFixture" do
   specify "it works" do
     output = run_rspec("any_fixture")

--- a/spec/integrations/before_all_spec.rb
+++ b/spec/integrations/before_all_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "BeforeAll" do
   context "RSpec" do
     it "works" do

--- a/spec/integrations/event_prof_minitest_spec.rb
+++ b/spec/integrations/event_prof_minitest_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "EventProf" do
   specify "Minitest integration with default rank by time", :aggregate_failures do
     output = run_minitest("event_prof", env: {"EVENT_PROF" => "test.event"})

--- a/spec/integrations/event_prof_spec.rb
+++ b/spec/integrations/event_prof_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "EventProf RSpec" do
   specify "with default options", :aggregate_failures do
     output = run_rspec("event_prof", env: {"EVENT_PROF" => "test.event"})

--- a/spec/integrations/factory_all_stub_spec.rb
+++ b/spec/integrations/factory_all_stub_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "FactoryAllStub" do
   specify "it works" do
     output = run_rspec("factory_all_stub")

--- a/spec/integrations/factory_default_spec.rb
+++ b/spec/integrations/factory_default_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "FactoryDefault" do
   specify "RSpec integration", :aggregate_failures do
     output = run_rspec("factory_default")

--- a/spec/integrations/factory_doctor_spec.rb
+++ b/spec/integrations/factory_doctor_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "FactoryDoctor" do
   context "Minitest Integration" do
     it "works when there are bad examples", :aggregate_failures do

--- a/spec/integrations/factory_prof_spec.rb
+++ b/spec/integrations/factory_prof_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "FactoryProf" do
   context "RSpec integration" do
     specify "simple printer", :aggregate_failures do

--- a/spec/integrations/let_it_be_spec.rb
+++ b/spec/integrations/let_it_be_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "LetItBe" do
   specify "it works" do
     output = run_rspec("let_it_be")

--- a/spec/integrations/profilers_spec.rb
+++ b/spec/integrations/profilers_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 PROFILERS_AVAILABLE =
   begin
     require "stackprof"

--- a/spec/integrations/rspec_dissect_spec.rb
+++ b/spec/integrations/rspec_dissect_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "RSpecDissect" do
   specify "it works", :aggregate_failures do
     output = run_rspec("rspec_dissect", env: {"RD_PROF" => "1"})

--- a/spec/integrations/rspec_stamp_spec.rb
+++ b/spec/integrations/rspec_stamp_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "RSpecStamp" do
   before do
     FileUtils.cp(

--- a/spec/integrations/sample_spec.rb
+++ b/spec/integrations/sample_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "Tests Sampling" do
   context "RSpec integration" do
     specify "SAMPLE=2" do

--- a/spec/integrations/tag_prof_spec.rb
+++ b/spec/integrations/tag_prof_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "TagProf" do
   specify "it works", :aggregate_failures do
     output = run_rspec("tag_prof", env: {"TAG_PROF" => "type"})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-require "test-prof"
 begin
   require "pry-byebug"
 rescue LoadError # rubocop:disable Lint/HandleExceptions

--- a/spec/test_prof/any_fixture_spec.rb
+++ b/spec/test_prof/any_fixture_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "test_prof/any_fixture"
 
 describe TestProf::AnyFixture, :transactional do

--- a/spec/test_prof/event_prof/profiler_spec.rb
+++ b/spec/test_prof/event_prof/profiler_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe TestProf::EventProf::Profiler do
   let(:rank_by) { :time }
   let(:top_count) { 5 }

--- a/spec/test_prof/event_prof_spec.rb
+++ b/spec/test_prof/event_prof_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe TestProf::EventProf do
   # Use fresh config all for every example
   after { described_class.remove_instance_variable(:@config) }

--- a/spec/test_prof/ext/active_record_refind_spec.rb
+++ b/spec/test_prof/ext/active_record_refind_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "test_prof/ext/active_record_refind"
 
 using TestProf::Ext::ActiveRecordRefind

--- a/spec/test_prof/ext/float_duration_spec.rb
+++ b/spec/test_prof/ext/float_duration_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "test_prof/ext/float_duration"
 
 using TestProf::FloatDuration

--- a/spec/test_prof/ext/string_truncate_spec.rb
+++ b/spec/test_prof/ext/string_truncate_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "test_prof/ext/string_truncate"
 
 using TestProf::StringTruncate

--- a/spec/test_prof/factory_doctor_spec.rb
+++ b/spec/test_prof/factory_doctor_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 # Init FactoryDoctor and patch TestProf::FactoryBot
 TestProf::FactoryDoctor.init
 

--- a/spec/test_prof/factory_prof/printers/flamegraph_spec.rb
+++ b/spec/test_prof/factory_prof/printers/flamegraph_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe TestProf::FactoryProf::Printers::Flamegraph do
   subject { described_class }
 

--- a/spec/test_prof/factory_prof_spec.rb
+++ b/spec/test_prof/factory_prof_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 # Init FactoryProf and patch TestProf::FactoryBot, Fabrication
 TestProf::FactoryProf.init
 TestProf::FactoryProf.configure do |config|

--- a/spec/test_prof/recipes/active_record_shared_connection_spec.rb
+++ b/spec/test_prof/recipes/active_record_shared_connection_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "test_prof/recipes/active_record_one_love"
 
 describe TestProf::ActiveRecordSharedConnection, :transactional do

--- a/spec/test_prof/rspec_stamp/parser_spec.rb
+++ b/spec/test_prof/rspec_stamp/parser_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "test_prof/rspec_stamp/parser"
 
 describe TestProf::RSpecStamp::Parser do

--- a/spec/test_prof/rspec_stamp_spec.rb
+++ b/spec/test_prof/rspec_stamp_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "test_prof/rspec_stamp"
 
 describe TestProf::RSpecStamp do

--- a/spec/test_prof/ruby_prof_spec.rb
+++ b/spec/test_prof/ruby_prof_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe TestProf::RubyProf do
   # Use fresh config all for every example
   after { described_class.remove_instance_variable(:@config) }

--- a/spec/test_prof/stack_prof_spec.rb
+++ b/spec/test_prof/stack_prof_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe TestProf::StackProf do
   # Use fresh config all for every example
   after { described_class.remove_instance_variable(:@config) }

--- a/spec/test_prof/utils/sized_ordered_set_spec.rb
+++ b/spec/test_prof/utils/sized_ordered_set_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "test_prof/utils/sized_ordered_set"
 
 describe TestProf::Utils::SizedOrderedSet do

--- a/spec/test_prof/utils_spec.rb
+++ b/spec/test_prof/utils_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "test_prof"
 
 describe TestProf::Utils do

--- a/spec/test_prof_spec.rb
+++ b/spec/test_prof_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe TestProf do
   describe "#artifact_path" do
     before do


### PR DESCRIPTION
### What is the purpose of this pull request?

Get rid of some boilerplate with an unnoticeable trade-off.

In addition to that:
 - it's possible to add `binding.pry` in the spec code without `require 'pry'`
 - RSpec's config is being loaded, which:
 - - adds and removes `tmp`
 - - sets execution order to `random` when running separate spec files (even those that didn't include `spec_helper` - found two issues in `let_it_be` with random order being set

More on the trade-off part below.

According to my measurements, time to run a single spec is 1.15s after,
and 0.9s before this change for `let_it_be_fixture.rb`.

When running the entire suite one by one (for each spec file RSpec
initialization is repeated to accumulate the effect), the difference is
even less noticeable:

    $ time fd _spec.rb | xargs -n 1 rspec

before:

    xargs -n 1 rspec  106.96s user 24.19s system 88% cpu 2:28.19 total

after:

    xargs -n 1 rspec  108.26s user 24.49s system 88% cpu 2:29.71 total

### What changes did you make? (overview)

Removed explicit requires of `spec_helper` and added a directive to require it from `.rspec` config file.

### Is there anything you'd like reviewers to focus on?

I might have missed some of the integration files in my benchmark. Is there anything else?

Side observation: example persistence file setting is useless:

```ruby
  config.example_status_persistence_file_path = "tmp/.rspec-status" if
    config.respond_to?(:example_status_persistence_file_path=)

  config.after(:suite) do
    FileUtils.rm_rf("tmp")
  end
```

should either be outside of `tmp`, or `tmp` should be kept after spec execution.

### Checklist

- [-] I've added tests for this change
- [-] I've added a Changelog entry
- [-] I've updated a documentation