### PR TITLE
Fix `let_it_be` issue with `create_pair`/`create_list`/`where`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Fix `let_it_be` issue when initialized with an array/enumerable or an AR relation. ([@pirj][])
+
 ## 0.10.2 (2020-01-07) 🎄
 
 - Fix Ruby 2.7 deprecations. ([@lostie][])
@@ -515,3 +517,4 @@ Fixes [#10](https://github.com/palkan/test-prof/issues/10).
 [@Envek]: https://github.com/Envek
 [@tyleriguchi]: https://github.com/tyleriguchi
 [@lostie]: https://github.com/lostie
+[@pirj]: https://github.com/pirj

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -134,14 +134,26 @@ if defined?(::ActiveRecord)
   TestProf::LetItBe.configure do |config|
     config.register_modifier :reload do |record, val|
       next record unless val
-      next record unless record.is_a?(::ActiveRecord::Base)
-      record.reload
+      next record.reload if record.is_a?(::ActiveRecord::Base)
+
+      if record.respond_to?(:map)
+        next record.map do |rec|
+          rec.is_a?(::ActiveRecord::Base) ? rec.reload : rec
+        end
+      end
+      record
     end
 
     config.register_modifier :refind do |record, val|
       next record unless val
-      next record unless record.is_a?(::ActiveRecord::Base)
-      record.refind
+      next record.refind if record.is_a?(::ActiveRecord::Base)
+
+      if record.respond_to?(:map)
+        next record.map do |rec|
+          rec.is_a?(::ActiveRecord::Base) ? rec.refind : rec
+        end
+      end
+      record
     end
   end
 end

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -4,15 +4,6 @@ require "test_prof"
 require_relative "./before_all"
 
 module TestProf
-  # Add `#map` to Object as an alias for `then` to use in modifiers
-  using(Module.new do
-    refine Object do
-      def map
-        yield self
-      end
-    end
-  end)
-
   # Just like `let`, but persist the result for the whole group.
   # NOTE: Experimental and magical, for more control use `before_all`.
   module LetItBe
@@ -52,10 +43,9 @@ module TestProf
         validate_modifiers! mods
 
         -> {
-          instance_eval(&block).map do |record|
-            mods.inject(record) do |rec, (k, v)|
-              LetItBe.modifiers.fetch(k).call(rec, v)
-            end
+          record = instance_eval(&block)
+          mods.inject(record) do |rec, (k, v)|
+            LetItBe.modifiers.fetch(k).call(rec, v)
           end
         }
       end

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -47,9 +47,9 @@ module TestProf
       end
 
       def wrap_with_modifiers(mods, &block)
-        validate_modifiers! mods
-
         return block if mods.empty?
+
+        validate_modifiers! mods
 
         -> {
           instance_eval(&block).map do |record|

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -186,7 +186,7 @@ describe "User", :transactional do
   end
 end
 
-describe "User", :transactional, :with_user do
+describe "User", :transactional do
   context "with shared context" do
     it "works", :with_user do
       expect(User.where(name: "Lolo").count).to eq 1

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -107,7 +107,7 @@ describe "User", :transactional do
       end
     end
 
-    context "with arrays" do
+    context "with arrays", order: :defined do
       let_it_be(:posts, refind: true) { create_pair(:post) }
 
       it "returns array" do

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -39,10 +39,7 @@ describe "User", :transactional do
   context "with let_it_be" do
     let_it_be(:user) { create(:user) }
 
-    it "has name" do
-      @cache[:user_name] = user.name
-      expect(user).to respond_to(:name)
-    end
+    before(:all) { @cache[:user_name] = user.name }
 
     it "is cached" do
       expect(user.name).to eq @cache[:user_name]


### PR DESCRIPTION
### What is the purpose of this pull request?

If `let_it_be` is initialized with either of:

    let_it_be(:posts) { create_pair(:post) }

or even:

    let_it_be(:posts) { author.posts }

i.e. in the former case it's an `Array`, and in the latter it's an `Post::ActiveRecord_Relation`, but none of them is an `ActiveRecord::Base`, so modifiers were returning early and skipping their jobs.

### What changes did you make? (overview)

Fix `let_it_be` issue with `create_pair`/`create_list`/`where`.

Fix run order-dependent spec.

Simplify the code a bit by getting rid of a refinement.

Allowed to skip mods validation if there are no mods.

### Is there anything you'd like reviewers to focus on?

¯\\\_(ツ)_/¯

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [-] I've updated a documentation