### PR TITLE
Disable AggregateFailures by default

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -22,7 +22,7 @@ RSpec/AggregateExamples:
 # TODO: remove this one we hit 1.0
 RSpec/AggregateFailures:
   Description: Checks if example groups contain two or more aggregatable examples.
-  Enabled: true
+  Enabled: false
   StyleGuide: https://rspec.rubystyle.guide/#expectation-per-example
   AddAggregateFailuresMetadata: true
   MatchersWithSideEffects:


### PR DESCRIPTION
### What is the purpose of this pull request?

Disable AggregateFailures by default and keep AggregateExamples enabled.

According to [docs, it had to be enabled explicitly](https://github.com/palkan/test-prof/blame/c01b309f4534e93b614dd2b79ac1f7f7ec1d92f3/docs/rubocop.md#L19) previously.

### What changes did you make? (overview)

Disabled AggregateFailures in RuboCop default config.

### Is there anything you'd like reviewers to focus on?

AggregateExamples is enabled, so for those who have enabled AggregateFailures, double the offences will be shown, and a deprecation warning regarding AggregateFailures.
It will bring double the attention to deprecation, and fix is trivial - remove AggregateFailures from user RuboCop config.

### Checklist

- [-] I've added tests for this change
- [-] I've added a Changelog entry
- [-] I've updated a documentation