### PR TITLE
Allow StackProf interval to be configured by ENV VAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   See more in [#181](https://github.com/palkan/test-prof/issues/181).
 
+- Adds the ability to define stackprof's interval sampling by using `TEST_STACK_PROF_INTERVAL` env variable ([@LynxEyes][])
+
+  Now you can use `$ TEST_STACK_PROF=1 TEST_STACK_PROF_INTERVAL=10000 rspec` to define a custom interval (in microseconds).
+
 ## 0.11.3 (2020-02-11)
 
 - Disable `RSpec/AggregateFailures` by default. ([@pirj][])
@@ -542,3 +546,4 @@ Fixes [#10](https://github.com/palkan/test-prof/issues/10).
 [@tyleriguchi]: https://github.com/tyleriguchi
 [@lostie]: https://github.com/lostie
 [@pirj]: https://github.com/pirj
+[@LynxEyes]: https://github.com/LynxEyes

--- a/docs/stack_prof.md
+++ b/docs/stack_prof.md
@@ -70,6 +70,10 @@ TEST_STACK_PROF=boot rspec ./spec/some_spec.rb
 
 ## Configuration
 
-You can change StackProf mode (which is `wall` by default) through `TEST_STACK_PROF_MODE` env variable.
+You can change StackProf mode (which is `wall` by default) through `TEST_STACK_PROF_MODE` env variable.  
+
+You can also change StackProf interval through `TEST_STACK_PROF_INTERVAL` env variable.  
+For modes `wall` and `cpu`, `TEST_STACK_PROF_INTERVAL` represents microseconds and will default to 1000 as per `stackprof`.  
+For mode `object`, `TEST_STACK_PROF_INTERVAL` represents allocations and will default to 1 as per `stackprof`.
 
 See [stack_prof.rb](https://github.com/palkan/test-prof/tree/master/lib/test_prof/stack_prof.rb) for all available configuration options and their usage.

--- a/docs/stack_prof.md
+++ b/docs/stack_prof.md
@@ -70,10 +70,10 @@ TEST_STACK_PROF=boot rspec ./spec/some_spec.rb
 
 ## Configuration
 
-You can change StackProf mode (which is `wall` by default) through `TEST_STACK_PROF_MODE` env variable.  
+You can change StackProf mode (which is `wall` by default) through `TEST_STACK_PROF_MODE` env variable.
 
-You can also change StackProf interval through `TEST_STACK_PROF_INTERVAL` env variable.  
-For modes `wall` and `cpu`, `TEST_STACK_PROF_INTERVAL` represents microseconds and will default to 1000 as per `stackprof`.  
+You can also change StackProf interval through `TEST_STACK_PROF_INTERVAL` env variable.
+For modes `wall` and `cpu`, `TEST_STACK_PROF_INTERVAL` represents microseconds and will default to 1000 as per `stackprof`.
 For mode `object`, `TEST_STACK_PROF_INTERVAL` represents allocations and will default to 1 as per `stackprof`.
 
 See [stack_prof.rb](https://github.com/palkan/test-prof/tree/master/lib/test_prof/stack_prof.rb) for all available configuration options and their usage.

--- a/lib/test_prof/stack_prof.rb
+++ b/lib/test_prof/stack_prof.rb
@@ -36,6 +36,9 @@ module TestProf
           else
             "html"
           end
+
+        sample_interval = ENV["TEST_STACK_PROF_INTERVAL"].to_i
+        @interval = sample_interval > 0 ? sample_interval : nil
       end
 
       def raw?


### PR DESCRIPTION
### What is the purpose of this pull request?

This PR adds the ability to configure stackprof's sample interval through an env var, similar to the rest of the options already do.

If you have a large test suite, using the default interval will create a massive dump file that is likely to end up being useless.
With this you can now configure the interval like so:

```
TEST_STACK_PROF=1 TEST_STACK_PROF_INTERVAL=10000 rspec
```

### What changes did you make? (overview)

I added parsing for the env var while ensuring no behaviour changes for those not using the env var.
Also added a couple of line on the docs.

### Is there anything you'd like reviewers to focus on?

I haven't seen tests around this "get the init from env vars" anywhere - I may have missed them...
If they don't exist, should I create them?
If they do, my bad.. let me know what should I do then.

### Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation