### PR TITLE
Fix DB not being rolled back between sibling RSpec examples for `before_all`/`let_it_be`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
   Now you can use `$ TEST_STACK_PROF=1 TEST_STACK_PROF_INTERVAL=10000 rspec` to define a custom interval (in microseconds).
 
+- Fix `let_it_be` and `before_all` not rolling back between sibling examples. ([@pirj][])
+
 ## 0.11.3 (2020-02-11)
 
 - Disable `RSpec/AggregateFailures` by default. ([@pirj][])

--- a/lib/test_prof/before_all.rb
+++ b/lib/test_prof/before_all.rb
@@ -16,24 +16,26 @@ module TestProf
       attr_accessor :adapter
 
       def begin_transaction
+        raise "begin_transaction does not support a block" if block_given?
         raise AdapterMissing if adapter.nil?
 
         config.run_hooks(:begin) do
           adapter.begin_transaction
         end
-        yield
-      end
-
-      def within_transaction
-        yield
       end
 
       def rollback_transaction
-        raise AdapterMissing if adapter.nil?
-
         config.run_hooks(:rollback) do
           adapter.rollback_transaction
         end
+      end
+
+      def begin_example_transaction
+        adapter.begin_transaction
+      end
+
+      def rollback_example_transaction
+        adapter.rollback_transaction
       end
 
       def config

--- a/lib/test_prof/recipes/minitest/before_all.rb
+++ b/lib/test_prof/recipes/minitest/before_all.rb
@@ -20,9 +20,8 @@ module TestProf
           return if active?
           @active = true
           @examples_left = test_class.runnable_methods.size
-          BeforeAll.begin_transaction do
-            capture!
-          end
+          BeforeAll.begin_transaction
+          capture!
         end
 
         def try_deactivate!

--- a/lib/test_prof/recipes/rspec/before_all.rb
+++ b/lib/test_prof/recipes/rspec/before_all.rb
@@ -9,26 +9,25 @@ module TestProf
       def before_all(&block)
         raise ArgumentError, "Block is required!" unless block_given?
 
-        return within_before_all(&block) if within_before_all?
+        return before(:all, &block) if within_before_all?
 
         @__before_all_activated__ = true
 
         before(:all) do
-          BeforeAll.begin_transaction do
-            instance_eval(&block)
-          end
+          BeforeAll.begin_transaction
+          instance_eval(&block)
         end
 
         after(:all) do
           BeforeAll.rollback_transaction
         end
-      end
 
-      def within_before_all(&block)
-        before(:all) do
-          BeforeAll.within_transaction do
-            instance_eval(&block)
-          end
+        before(:example) do
+          BeforeAll.begin_example_transaction
+        end
+
+        after(:example) do
+          BeforeAll.rollback_example_transaction
         end
       end
 

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -86,11 +86,7 @@ module TestProf
         instance_variable_set(:"#{PREFIX}#{identifier}", instance_exec(&block))
       end
 
-      if within_before_all?
-        within_before_all(&initializer)
-      else
-        before_all(&initializer)
-      end
+      before_all(&initializer)
 
       define_let_it_be_methods(identifier, **options)
     end

--- a/spec/integrations/fixtures/rspec/before_all_isolator_fixture.rb
+++ b/spec/integrations/fixtures/rspec/before_all_isolator_fixture.rb
@@ -38,20 +38,22 @@ class User < ActiveRecord::Base
 end
 
 describe "before_all + Isolator", :transactional do
-  before_all do
-    @user = User.create
-    SampleJob.perform_async(true)
-    @user.commited = true
-  end
+  context "with an implicit transaction" do
+    before_all do
+      @user = User.create
+      SampleJob.perform_async(true)
+      @user.commited = true
+    end
 
-  before_all do
-    @user2 = User.create
-    SampleJob.perform_async(true)
-  end
+    before_all do
+      @user2 = User.create
+      SampleJob.perform_async(true)
+    end
 
-  it "doesn't raise in after_commit callback" do
-    expect(@user.commited).to eq true
-    expect(@user2.commited).to be_nil
+    it "doesn't raise in after_commit callback" do
+      expect(@user.commited).to eq true
+      expect(@user2.commited).to be_nil
+    end
   end
 
   it "doesn't raise without transaction" do

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -190,3 +190,17 @@ describe "User", :transactional do
     end
   end
 end
+
+describe "does not leak", order: :defined do
+  include TestProf::FactoryBot::Syntax::Methods
+
+  let_it_be(:user, refind: true) { create(:user, name: "Original Name") }
+
+  it "leaks" do
+    user.update!(name: "John Doe")
+  end
+
+  it "is not affected by the leak" do
+    expect(user.name).to eq("Original Name")
+  end
+end


### PR DESCRIPTION
## The Problem

```ruby
describe "does not leak", order: :defined do
  include TestProf::FactoryBot::Syntax::Methods

  let_it_be(:user, refind: true) { create(:user, name: "Original Name") }

  it "leaks" do
    user.update!(name: "John Doe")
  end

  it "is not affected by the leak" do
    expect(user.name).to eq("Original Name")
  end
end
```

```
Modification detection
  association state leakage
    leaks
    suffers (FAILED - 1)

Failures:

  1) Modification detection association state leakage suffers
     Failure/Error: expect(post.user.name).to eq("Original Name")

       expected: "Original Name"
            got: "John Doe"
```

## Research

It surprised me that the database was not rolled back between sibling examples. Turns out `before(:all)` is not sufficient.

## The Solution

An additional nested transaction needs to be open/rolled back around every example.