### PR TITLE
Make SAMPLE and SAMPLE_GROUPS consistent with seed for Minitest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-- SAMPLE and SAMPLE_GROUP work consistently with seed in RSpec. ([@stefkin][])
+- SAMPLE and SAMPLE_GROUP work consistently with seed in RSpec and Minitest. ([@stefkin][])
 
 - Make sure EventProf is not affected by time freezing. ([@palkan][])
 

--- a/lib/minitest/test_prof_plugin.rb
+++ b/lib/minitest/test_prof_plugin.rb
@@ -12,6 +12,7 @@ module Minitest # :nodoc:
         opts[:top_count] = ENV["EVENT_PROF_TOP"].to_i if ENV["EVENT_PROF_TOP"]
         opts[:per_example] = true if ENV["EVENT_PROF_EXAMPLES"]
         opts[:fdoc] = true if ENV["FDOC"]
+        opts[:sample] = true if ENV["SAMPLE"] || ENV["SAMPLE_GROUPS"]
       end
     end
   end
@@ -39,5 +40,7 @@ module Minitest # :nodoc:
 
     reporter << TestProf::EventProfReporter.new(options[:io], options) if options[:event]
     reporter << TestProf::FactoryDoctorReporter.new(options[:io], options) if options[:fdoc]
+
+    ::TestProf::MinitestSample.call if options[:sample]
   end
 end

--- a/lib/test_prof/recipes/minitest/sample.rb
+++ b/lib/test_prof/recipes/minitest/sample.rb
@@ -35,18 +35,14 @@ module TestProf
           end
         end
       end
-    end
 
-    # Overrides Minitest.run
-    def run(*)
-      if ENV["SAMPLE"]
-        MinitestSample.sample_examples(ENV["SAMPLE"].to_i)
-      elsif ENV["SAMPLE_GROUPS"]
-        MinitestSample.sample_groups(ENV["SAMPLE_GROUPS"].to_i)
+      def call
+        if ENV["SAMPLE"]
+          ::TestProf::MinitestSample.sample_examples(ENV["SAMPLE"].to_i)
+        elsif ENV["SAMPLE_GROUPS"]
+          ::TestProf::MinitestSample.sample_groups(ENV["SAMPLE_GROUPS"].to_i)
+        end
       end
-      super
     end
   end
 end
-
-Minitest.singleton_class.prepend(TestProf::MinitestSample)

--- a/spec/integrations/sample_spec.rb
+++ b/spec/integrations/sample_spec.rb
@@ -73,7 +73,7 @@ describe "Tests Sampling" do
     specify "SAMPLE=2 with seed" do
       outputs = Array
         .new(10) { run_minitest("sample", env: {"SAMPLE" => "2", "TESTOPTS" => "-v --seed 42"}) }
-        .map { |output| output.gsub(/Finished in.*/, '') }
+        .map { |output| output.gsub(/Finished in.*/, "") }
 
       expect(outputs.uniq.size).to eq 1
     end
@@ -93,7 +93,7 @@ describe "Tests Sampling" do
     specify "SAMPLE_GROUPS=2 with seed" do
       outputs = Array
         .new(10) { run_minitest("sample", env: {"SAMPLE_GROUPS" => "2", "TESTOPTS" => "-v --seed 42"}) }
-        .map { |output| output.gsub(/Finished in.*/, '') }
+        .map { |output| output.gsub(/Finished in.*/, "") }
 
       expect(outputs.uniq.size).to eq 1
     end

--- a/spec/integrations/sample_spec.rb
+++ b/spec/integrations/sample_spec.rb
@@ -70,6 +70,14 @@ describe "Tests Sampling" do
       expect(output).to include("1 runs, 1 assertions, 0 failures, 0 errors, 0 skips")
     end
 
+    specify "SAMPLE=2 with seed" do
+      outputs = Array
+        .new(10) { run_minitest("sample", env: {"SAMPLE" => "2", "TESTOPTS" => "-v --seed 42"}) }
+        .map { |output| output.gsub(/Finished in.*/, '') }
+
+      expect(outputs.uniq.size).to eq 1
+    end
+
     specify "SAMPLE_GROUPS=1" do
       output = run_minitest("sample", env: {"SAMPLE_GROUPS" => "1"})
 
@@ -80,6 +88,14 @@ describe "Tests Sampling" do
       output = run_minitest("sample", env: {"SAMPLE_GROUPS" => "2"})
 
       expect(output).to include("4 runs, 4 assertions, 0 failures, 0 errors, 0 skips")
+    end
+
+    specify "SAMPLE_GROUPS=2 with seed" do
+      outputs = Array
+        .new(10) { run_minitest("sample", env: {"SAMPLE_GROUPS" => "2", "TESTOPTS" => "-v --seed 42"}) }
+        .map { |output| output.gsub(/Finished in.*/, '') }
+
+      expect(outputs.uniq.size).to eq 1
     end
   end
 end


### PR DESCRIPTION
### What is the purpose of this pull request?

#187 for Minitest

### What changes did you make? (overview)

Instead of prepending Minitest's run I decided to move the code into test_prof_plugin init.

Now all the sampling we make is done after Minitest sets srand

https://github.com/seattlerb/minitest/blob/master/lib/minitest.rb#L231

and we get consistent sampling for free

### Is there anything you'd like reviewers to focus on?

please check if my inclusion of TestProf::MinitestSample into test prof plugin is ok.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
