### PR TITLE
Explicitly specify the config

### DIFF
--- a/spec/test_prof/cops/rspec/aggregate_examples_spec.rb
+++ b/spec/test_prof/cops/rspec/aggregate_examples_spec.rb
@@ -6,6 +6,10 @@ require "test_prof/cops/rspec/aggregate_examples"
 RSpec.describe RuboCop::Cop::RSpec::AggregateExamples, :config do
   subject(:cop) { described_class.new(config) }
 
+  let(:cop_config) do
+    {"AddAggregateFailuresMetadata" => false}
+  end
+
   shared_examples "flags in example group" do |group|
     it "flags examples in '#{group}'" do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
https://github.com/rubocop-hq/rubocop/pull/7970 in RuboCop 0.84 mixes in the default config, which changes the config options from "default" (missing) `false` to actual `true` from config/defaults.yml

### Checklist

- [-] I've added tests for this change
- [-] I've added a Changelog entry
- [-] I've updated a documentation