### PR TITLE
let_it_be enhancements

### DIFF
--- a/.github/workflows/rspec-jruby.yml
+++ b/.github/workflows/rspec-jruby.yml
@@ -31,4 +31,4 @@ jobs:
         bundle update
     - name: Run RSpec
       run: |
-        bundle exec rspec
+        bundle exec rspec --force-color

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -71,4 +71,4 @@ jobs:
         bundle update
     - name: Run RSpec
       run: |
-        bundle exec rspec
+        bundle exec rspec --force-color

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## master (unreleased)
 
+- Add state leakage detection for `let_it_be`. ([@pirj][], [@jaimerson][], [@alexvko][])
+
+- Add default let_it_be modifiers configuration. ([@palkan][])
+
+  You can configure global modifiers:
+
+  ```ruby
+  TestProf::LetItBe.configure do |config|
+    # Make refind activated by default
+    config.default_modifiers[:refind] = true
+  end
+  ```
+
+  Or for specific contexts via tags:
+
+  ```ruby
+  context "with let_it_be reload", let_it_be_modifiers: {reload: true} do
+    # examples
+  end
+  ```
+
 - **Drop Ruby 2.4 support.** ([@palkan][])
 
 - SAMPLE and SAMPLE_GROUP work consistently with seed in RSpec and Minitest. ([@stefkin][])
@@ -15,8 +36,6 @@
 - Adds the ability to define stackprof's interval sampling by using `TEST_STACK_PROF_INTERVAL` env variable ([@LynxEyes][])
 
   Now you can use `$ TEST_STACK_PROF=1 TEST_STACK_PROF_INTERVAL=10000 rspec` to define a custom interval (in microseconds).
-
-- Add state leakage detection for `let_it_be`. ([@pirj][], [@jaimerson][], [@alexvko][])
 
 ## 0.11.3 (2020-02-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
   Now you can use `$ TEST_STACK_PROF=1 TEST_STACK_PROF_INTERVAL=10000 rspec` to define a custom interval (in microseconds).
 
+- Add naïve state leakage detection for `let_it_be`. ([@pirj][], [@jaimerson][])
+
 ## 0.11.3 (2020-02-11)
 
 - Disable `RSpec/AggregateFailures` by default. ([@pirj][])
@@ -552,3 +554,4 @@ Fixes [#10](https://github.com/palkan/test-prof/issues/10).
 [@pirj]: https://github.com/pirj
 [@LynxEyes]: https://github.com/LynxEyes
 [@stefkin]: https://github.com/stefkin
+[@jaimerson]: https://github.com/jaimerson

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
   Now you can use `$ TEST_STACK_PROF=1 TEST_STACK_PROF_INTERVAL=10000 rspec` to define a custom interval (in microseconds).
 
-- Add naïve state leakage detection for `let_it_be`. ([@pirj][], [@jaimerson][])
+- Add state leakage detection for `let_it_be`. ([@pirj][], [@jaimerson][], [@alexvko][])
 
 ## 0.11.3 (2020-02-11)
 
@@ -555,3 +555,4 @@ Fixes [#10](https://github.com/palkan/test-prof/issues/10).
 [@LynxEyes]: https://github.com/LynxEyes
 [@stefkin]: https://github.com/stefkin
 [@jaimerson]: https://github.com/jaimerson
+[@alexvko]: https://github.com/alexvko

--- a/docs/let_it_be.md
+++ b/docs/let_it_be.md
@@ -165,9 +165,22 @@ TestProf::LetItBe.configure do |config|
 end
 ```
 
-### Auto-magic State Leakage Detection
+### Auto-magic State Leakage Detection [experimental]
 
 > @since v0.12.0
+
+This feature is opt-in, since it may find a significant number of leakages in specs that may be a significant burden to fix all at once.
+It's possible to gradually turn it on for parts of specs by using:
+
+```ruby
+# spec/spec_helper.rb
+RSpec.configure do |config|
+  # ...
+  config.define_derived_metadata(file_path: %r{/spec/models/}) do |metadata|
+    metadata[:let_it_be_frost] = true
+  end
+end
+```
 
 The code might modify models shared between examples.
 Unwillingly - if the underlying code under test modifies models, e.g. modifies `updated_at` attribute.
@@ -189,7 +202,7 @@ To fix the `FrozenError`:
 - add `reload: true`/`refind: true`, it pacifies leakage detection and prevents leakage itself. Typically it's significantly faster to reload the model than to re-create it from scratch before each example (two or even three orders of magnitude faster in some cases)
 - rewrite problematic test code
 
-In the case when modification is deliberate, it's possible to disable leakage detection individually with `freeze: false` `let_it_be` option, or for the whole example group with `let_it_be_defrost: true` RSpec metadata.
+In the case when modification is deliberate, it's possible to disable leakage detection individually with `freeze: false` `let_it_be` option, or for the whole example group with `let_it_be_frost: false` RSpec metadata.
 
 NOTE: If the code under test or the test code calls `reload` on models, the example will fail.
 To avoid this, set `reload: true` on corresponding `let_it_be` definitions.

--- a/docs/let_it_be.md
+++ b/docs/let_it_be.md
@@ -170,7 +170,7 @@ end
 > @since v0.12.0
 
 This feature is opt-in, since it may find a significant number of leakages in specs that may be a significant burden to fix all at once.
-It's possible to gradually turn it on for parts of specs by using:
+It's possible to gradually turn it on for parts of specs (e.g. only models) by using:
 
 ```ruby
 # spec/spec_helper.rb

--- a/lib/test_prof/before_all.rb
+++ b/lib/test_prof/before_all.rb
@@ -24,10 +24,6 @@ module TestProf
         yield
       end
 
-      def within_transaction
-        yield
-      end
-
       def rollback_transaction
         raise AdapterMissing if adapter.nil?
 

--- a/lib/test_prof/recipes/rspec/before_all.rb
+++ b/lib/test_prof/recipes/rspec/before_all.rb
@@ -9,7 +9,7 @@ module TestProf
       def before_all(&block)
         raise ArgumentError, "Block is required!" unless block_given?
 
-        return within_before_all(&block) if within_before_all?
+        return before(:all, &block) if within_before_all?
 
         @__before_all_activated__ = true
 
@@ -21,14 +21,6 @@ module TestProf
 
         after(:all) do
           BeforeAll.rollback_transaction
-        end
-      end
-
-      def within_before_all(&block)
-        before(:all) do
-          BeforeAll.within_transaction do
-            instance_eval(&block)
-          end
         end
       end
 

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -86,8 +86,8 @@ module TestProf
     end
 
     def let_it_be(identifier, **options, &block)
-      freeze = options.fetch(:freeze, !(options[:reload] || options[:refind])) &&
-        !metadata[:let_it_be_defrost]
+      freeze = metadata[:let_it_be_frost] &&
+        options.fetch(:freeze, !(options[:reload] || options[:refind]))
 
       initializer = build_let_it_be_initializer(identifier, freeze, &block)
       before_all(&initializer)
@@ -144,7 +144,7 @@ module TestProf
         object.each { |obj| freeze(obj) } if object.respond_to?(:each)
       end
 
-      # Rerucsively freezes the object to detect modifications.
+      # Rerucsively freezes the object to detect modifications
       def deep_freeze(record)
         return if record.frozen?
         return if stoplist.include?(record)
@@ -215,7 +215,8 @@ if defined?(::ActiveRecord::Base)
     end
 
     config.register_modifier :freeze do |record, val|
-      next record if val == false
+      # TODO: change this to `if val == false` when TestProf hits 1.0
+      next record unless val == true
 
       TestProf::LetItBe::Freezer.deep_freeze(record)
       record
@@ -223,7 +224,8 @@ if defined?(::ActiveRecord::Base)
   end
 else
   config.register_modifier :freeze do |record, val|
-    next record if val == false
+    # TODO: change this to `if val == false` when TestProf hits 1.0
+    next record unless val == true
 
     TestProf::LetItBe::Freezer.freeze(record)
     record

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -157,9 +157,9 @@ module TestProf
     #
     # Stoplist holds two types of records, one is "stop", and another is "skip".
     # "skip" is to skip freezing objects that are defined with `let_it_be`'s
-    # `reload: true`/`refind: true`, but to proceed with deep freezing their
-    # associations. "stop" is for stop deep freezing for those records declared
-    # with `freeze: false`.
+    # `reload: true`, but to proceed with deep freezing their associations.
+    # "stop" is for stop deep freezing for those records declared with
+    # `freeze: false` and `refind: true`.
     module Stoplist
       class << self
         def skip?(record)
@@ -189,8 +189,9 @@ module TestProf
         end
       end
 
-      @skiplist = [] # Stack of example group-related variable definitions
-      @stoplist = [] # Stack of example group-related variable definitions
+      # Stack of example group-related variable definitions
+      @skiplist = []
+      @stoplist = []
     end
   end
 end
@@ -218,7 +219,7 @@ if defined?(::ActiveRecord::Base)
     config.register_modifier :refind do |record, val|
       next record unless val
 
-      TestProf::LetItBe::Stoplist.skip!(record)
+      TestProf::LetItBe::Stoplist.stop!(record)
 
       next record.refind if record.is_a?(::ActiveRecord::Base)
 

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -38,8 +38,7 @@ module TestProf
       end
 
       def wrap_with_modifiers(mods, &block)
-        # return block if mods.empty?
-        mods = {freeze: true}.merge(mods)
+        return block if mods.empty?
 
         validate_modifiers! mods
 
@@ -184,9 +183,10 @@ if defined?(::ActiveRecord::Base)
   TestProf::LetItBe.configure do |config|
     config.register_modifier :reload do |record, val|
       next record unless val
-      next record.reload if record.is_a?(::ActiveRecord::Base)
 
       TestProf::LetItBe::Stoplist.push(record)
+
+      next record.reload if record.is_a?(::ActiveRecord::Base)
 
       if record.respond_to?(:map)
         next record.map do |rec|
@@ -198,9 +198,10 @@ if defined?(::ActiveRecord::Base)
 
     config.register_modifier :refind do |record, val|
       next record unless val
-      next record.refind if record.is_a?(::ActiveRecord::Base)
 
       TestProf::LetItBe::Stoplist.push(record)
+
+      next record.refind if record.is_a?(::ActiveRecord::Base)
 
       if record.respond_to?(:map)
         next record.map do |rec|

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -81,10 +81,34 @@ module TestProf
       end
     end
 
+    # Some of the examples might (unwillingly, or deliberately) update
+    # model attributes.
+    # Unwillingly - if the underlying code under test modifies models, e.g.
+    # modifies `updated_at` attribute.
+    # Deliberately - if models are updated in `before` hooks or examples
+    # themselves instead of creating models in a proper state initially.
+    #
+    # It doesn't really matter if the database is modified or not since
+    # it's rolled back to a pristine state.
+    # However, since models created with `let_it_be` are shared between
+    # the examples, non-reloaded changes to models remain and leak between
+    # examples.
+    #
+    # This leads to unpredictable failures, and in worst case scenario
+    # examples that implicitly depend on other examples.
+    #
+    # Root cause is hard to track down, especially with random example
+    # execution order. A spec might fail with --seed 1001, but pass with
+    # 1002 & 1003.
+    #
+    # With many shared models between many examples, it's also hard to
+    # track down the example and exact place in the code that modifies
+    # the model. Even though the fix is trivial - to add set `refind` or
+    # `reload` options, it's rarely obvious where it should be set
+    # exactly.
     def let_it_be(identifier, **options, &block)
-      initializer = proc do
-        instance_variable_set(:"#{PREFIX}#{identifier}", instance_exec(&block))
-      end
+      freeze = options.fetch(:freeze, !(options[:reload] || options[:refind]))
+      initializer = build_initializer(identifier, freeze, &block)
 
       if within_before_all?
         within_before_all(&initializer)
@@ -92,7 +116,45 @@ module TestProf
         before_all(&initializer)
       end
 
-      define_let_it_be_methods(identifier, **options)
+      define_let_it_be_methods(identifier, **options.except(:freeze))
+      handle_frozen_hash_error
+    end
+
+    FROZEN_HASH_REGEX = /can't modify frozen Hash/
+    FROZEN_HASH_HINT = "\nIf you are using `let_it_be`, you may want to pass `reload: true` option to it."
+
+    # Exception needs to be handled both here and in `handle_frozen_hash_error`
+    # because if it is raised in before_all it isn't caught in `after` block and
+    # if it's inside the example it isn't raised so it has to be handled in `after`.
+    def build_initializer(identifier, freeze, &block)
+      proc do
+        begin
+          record = instance_exec(&block)
+          if freeze
+            record.freeze
+            record.each(&:freeze) if record.respond_to?(:each)
+          end
+
+          instance_variable_set(:"#{TestProf::LetItBe::PREFIX}#{identifier}", record)
+        rescue => e
+          raise e unless e.message.match?(FROZEN_HASH_REGEX)
+          e.message << FROZEN_HASH_HINT
+          raise e
+        end
+      end
+    end
+
+    def handle_frozen_hash_error
+      # Prevent `after` block from being defined several times
+      return if metadata[:"#{PREFIX}frozen_hash_handled"]
+
+      prepend_after do |example|
+        if example.exception&.message&.match?(FROZEN_HASH_REGEX)
+          example.exception.message << FROZEN_HASH_HINT
+        end
+      end
+
+      metadata[:"#{PREFIX}frozen_hash_handled"] = true
     end
 
     def define_let_it_be_methods(identifier, **modifiers)

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -105,11 +105,7 @@ module TestProf
       end
       before_all(&initializer)
 
-      define_let_it_be_methods(identifier, **options.except(:freeze))
-    end
-
-    def define_let_it_be_methods(identifier, **modifiers)
-      let_accessor = LetItBe.wrap_with_modifiers(modifiers) do
+      let_accessor = LetItBe.wrap_with_modifiers(options.except(:freeze)) do
         instance_variable_get(:"#{PREFIX}#{identifier}")
       end
 

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -129,9 +129,9 @@ module TestProf
           return record.each { |rec| deep_freeze(rec) } if record.respond_to?(:each)
 
           # Freeze associations as well.
-          # NOTE: `reload` statements in test or production code will cause
-          # a `FrozenError`. In case the use of `reload` cannot be avoided, use
-          # `reload: true` in `let_it_be` declaration.
+          # NOTE: `reload` statements in test or production code will cause a `FrozenError`
+          # (or a `TypeError` on earlier Rubies). In case the use of `reload` cannot be
+          # avoided, use `reload: true` in `let_it_be` declaration.
           return unless defined?(::ActiveRecord::Base)
           return unless record.is_a?(::ActiveRecord::Base)
 

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -2,6 +2,7 @@
 
 require "test_prof"
 require_relative "./before_all"
+require "set"
 
 module TestProf
   # Just like `let`, but persist the result for the whole group.
@@ -38,7 +39,8 @@ module TestProf
       end
 
       def wrap_with_modifiers(mods, &block)
-        return block if mods.empty?
+        # return block if mods.empty?
+        mods = {freeze: true}.merge(mods)
 
         validate_modifiers! mods
 
@@ -84,12 +86,11 @@ module TestProf
     end
 
     def let_it_be(identifier, **options, &block)
-      freeze = options.fetch(:freeze, !(options[:reload] || options[:refind]))
+      freeze = options.fetch(:freeze, !(options[:reload] || options[:refind])) &&
+        !metadata[:let_it_be_defrost]
 
       initializer = build_let_it_be_initializer(identifier, freeze, &block)
       before_all(&initializer)
-
-      define_freezing_hooks if freeze && !metadata[:let_it_be_defrost]
 
       define_let_it_be_methods(identifier, **options.except(:freeze))
     end
@@ -114,20 +115,6 @@ module TestProf
       let(identifier, &let_accessor)
     end
 
-    def define_freezing_hooks
-      # Prevent hooks from being defined several times
-      return if instance_variable_get(:"#{PREFIX}hooks_defined")
-
-      before(:all) do
-        let_it_be_objects = instance_variable_get(:"#{PREFIX}let_it_be_objects")
-        let_it_be_stoplist = instance_variable_get(:"#{PREFIX}let_it_be_stoplist")
-
-        let_it_be_objects.each { |object| Freezer.deep_freeze(object, let_it_be_stoplist) }
-      end
-
-      instance_variable_set(:"#{PREFIX}hooks_defined", true)
-    end
-
     # Exception needs to be handled both here and in `handle_frozen_hash_error`
     # because if it is raised in before_all it isn't caught in `after` block and
     # if it's inside the example it isn't raised so it has to be handled in `after`.
@@ -136,15 +123,9 @@ module TestProf
         begin
           record = instance_exec(&block)
 
-          let_it_be_objects = instance_variable_get(:"#{PREFIX}let_it_be_objects")
-          let_it_be_objects ||= instance_variable_set(:"#{PREFIX}let_it_be_objects", [])
-          let_it_be_stoplist = instance_variable_get(:"#{PREFIX}let_it_be_stoplist")
-          let_it_be_stoplist ||= instance_variable_set(:"#{PREFIX}let_it_be_stoplist", [])
-          if freeze
-            let_it_be_objects << record
-          else
-            let_it_be_stoplist << record
-          end
+          # Prevent records that are marked as `freeze: false`, `reload: true`, and
+          # `refind: true` from being frozen by walking the association tree.
+          Freezer.stoplist << record unless freeze
 
           instance_variable_set(:"#{TestProf::LetItBe::PREFIX}#{identifier}", record)
         rescue => e
@@ -155,21 +136,29 @@ module TestProf
     end
 
     module Freezer
+      module_function
+
+      def freeze(object)
+        object.freeze
+        # Support `let_it_be` with a list of objects
+        object.each { |obj| freeze(obj) } if object.respond_to?(:each)
+      end
+
       # Rerucsively freezes the object to detect modifications.
-      def self.deep_freeze(record, stoplist)
+      def deep_freeze(record)
         return if record.frozen?
         return if stoplist.include?(record)
 
         record.freeze
 
-        return record.each { |rec| deep_freeze(rec, stoplist) } if record.respond_to?(:each)
+        # Support `let_it_be` with `create_list`
+        return record.each { |rec| deep_freeze(rec) } if record.respond_to?(:each)
 
         # Freeze associations as well.
-        #
         # NOTE: `reload` statements in test or production code will cause
         # a `FrozenError`. In case the use of `reload` cannot be avoided, use
         # `reload: true` in `let_it_be` declaration.
-        return unless defined?(::ActiveRecord)
+        return unless defined?(::ActiveRecord::Base)
         return unless record.is_a?(::ActiveRecord::Base)
 
         record.class.reflections.keys.each do |reflection|
@@ -178,16 +167,25 @@ module TestProf
           next unless record.association(reflection.to_sym).loaded?
 
           target = record.association(reflection.to_sym).target
-          if target.is_a?(::ActiveRecord::Base) || target.is_a?(Array)
-            deep_freeze(target, stoplist)
-          end
+          deep_freeze(target) if target.is_a?(::ActiveRecord::Base) || target.respond_to?(:each)
         end
+      end
+
+      # Stoplist to prevent freezing objects that are defined with `let_it_be`'s
+      # `reload: true`/`refind: true`/`freeze: false` options during deep freezing.
+      # NOTE: it's intentionally implemented as a thread-local var.
+      def stoplist
+        Thread.current[:"#{TestProf::LetItBe::PREFIX}stoplist"] ||= Set.new
+      end
+
+      def reset_stoplist
+        stoplist.clear
       end
     end
   end
 end
 
-if defined?(::ActiveRecord)
+if defined?(::ActiveRecord::Base)
   require "test_prof/ext/active_record_refind"
   using TestProf::Ext::ActiveRecordRefind
 
@@ -215,6 +213,20 @@ if defined?(::ActiveRecord)
       end
       record
     end
+
+    config.register_modifier :freeze do |record, val|
+      next record if val == false
+
+      TestProf::LetItBe::Freezer.deep_freeze(record)
+      record
+    end
+  end
+else
+  config.register_modifier :freeze do |record, val|
+    next record if val == false
+
+    TestProf::LetItBe::Freezer.freeze(record)
+    record
   end
 end
 
@@ -224,5 +236,15 @@ RSpec.configure do |config|
     if example.exception&.message&.match?(/can't modify frozen/)
       example.exception.message << TestProf::LetItBe::FROZEN_ERROR_HINT
     end
+  end
+end
+
+# Reset stoplist, a list of objects defined with `let_it_be`'s `reload: true`/
+# `refind: true` to reduce its lifecycle from suite-wide to spec-wide.
+TestProf::BeforeAll.configure do |config|
+  config.after(:rollback) do
+    # TODO: make sure BeforeAll does not call it on *each* rollback,
+    # just the outermost one.
+    TestProf::LetItBe::Freezer.reset_stoplist
   end
 end

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -91,7 +91,7 @@ module TestProf
           record = instance_exec(&block)
           instance_variable_set(:"#{TestProf::LetItBe::PREFIX}#{identifier}", record)
         rescue => e
-          e.message << FROZEN_ERROR_HINT if e.message.match?(/can't modify frozen/)
+          e.message << FROZEN_ERROR_HINT if e.message.match?(/[Cc]an't modify frozen/)
           raise e
         end
       end
@@ -246,7 +246,7 @@ end
 RSpec::Core::ExampleGroup.extend TestProf::LetItBe
 RSpec.configure do |config|
   config.after(:example) do |example|
-    if example.exception&.message&.match?(/can't modify frozen/)
+    if example.exception&.message&.match?(/[Cc]an't modify frozen/)
       example.exception.message << TestProf::LetItBe::FROZEN_ERROR_HINT
     end
   end

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -117,8 +117,8 @@ RSpec.describe "User", :transactional do
     end
 
     context "with custom modifier" do
-      let_it_be(:post, freeze: false, touch_with_shift: true) { create(:post, created_at: 1.day.ago) }
-      let_it_be(:post2, freeze: false, touch_with_shift: 2) { create(:post, created_at: 1.day.ago) }
+      let_it_be(:post, touch_with_shift: true) { create(:post, created_at: 1.day.ago) }
+      let_it_be(:post2, touch_with_shift: 2) { create(:post, created_at: 1.day.ago) }
 
       it "applies custom modifier" do
         expect(post.created_at).to be >= 1.hour.ago

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -30,7 +30,7 @@ TestProf::LetItBe.configure do |config|
   config.alias_to :let_with_refind, refind: true
 end
 
-RSpec.describe "User", :transactional, let_it_be_frost: true do
+RSpec.describe "User", :transactional do
   before(:all) do
     @cache = {}
   end

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 require_relative "../../../support/ar_models"
 require_relative "../../../support/transactional_context"
 

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -31,7 +31,7 @@ TestProf::LetItBe.configure do |config|
   config.alias_to :let_with_refind, refind: true
 end
 
-describe "User", :transactional do
+RSpec.describe "User", :transactional, let_it_be_frost: true do
   before(:all) do
     @cache = {}
   end

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -118,8 +118,8 @@ describe "User", :transactional do
     end
 
     context "with custom modifier" do
-      let_it_be(:post, touch_with_shift: true) { create(:post, created_at: 1.day.ago) }
-      let_it_be(:post2, touch_with_shift: 2) { create(:post, created_at: 1.day.ago) }
+      let_it_be(:post, freeze: false, touch_with_shift: true) { create(:post, created_at: 1.day.ago) }
+      let_it_be(:post2, freeze: false, touch_with_shift: 2) { create(:post, created_at: 1.day.ago) }
 
       it "applies custom modifier" do
         expect(post.created_at).to be >= 1.hour.ago

--- a/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
@@ -2,46 +2,87 @@
 
 require "test_prof/recipes/rspec/let_it_be"
 
-# `order: defined` is to make sure the example that modifies the state
-# is being run first, and the "victim" example runs afterwards.
-RSpec.describe "Modification detection on associations", order: :defined do
+RSpec.describe "Modification detection" do
   include TestProf::FactoryBot::Syntax::Methods
 
-  # If you add `freeze: false` `let_it_be` option, state will leak
-  # and the unsuspecting second example will fail.
-  let_it_be(:user) { create(:user, name: "Original Name") }
+  # `order: defined` is to make sure the example that modifies the state
+  # is being run first, and the "victim" example runs afterwards.
 
-  it "detects the leak" do
-    expect { user.update!(name: "John Doe") }
-      .to raise_error(FrozenError, /can't modify frozen Hash/)
+  describe "first order state leakage", order: :defined do
+    # If you add `freeze: false` `let_it_be` option, state will leak
+    # and the unsuspecting second example will fail.
+    let_it_be(:user) { create(:user, name: "Original Name") }
+
+    it "detects the leak" do
+      expect { user.update!(name: "John Doe") }
+        .to raise_error(FrozenError, /can't modify frozen/)
+    end
+
+    it { expect(user.name).to eq("Original Name") }
   end
 
-  it { expect(user.name).to eq("Original Name") }
+  describe "second order state leakage", order: :defined do
+    let_it_be(:post) { create(:post, user: create(:user, name: "Original Name")) }
+
+    it "detects the leak" do
+      expect { post.user.update!(name: "John Doe") }
+        .to raise_error(FrozenError, /can't modify frozen/)
+    end
+
+    it { expect(post.user.name).to eq("Original Name") }
+  end
 
   context "with an array of values" do
     let_it_be(:users) { create_list(:user, 2) }
 
-    it "detects the leak" do
+    it "detects the leak in an array item" do
       expect { users.first.update!(name: "John Doe") }
-        .to raise_error(FrozenError, /can't modify frozen Hash/)
+        .to raise_error(FrozenError, /can't modify frozen/)
+    end
+
+    it "detects the leak in the array itself" do
+      expect { users << "yet another user" }
+        .to raise_error(FrozenError, /can't modify frozen/)
     end
   end
 
   describe "infers `freeze: false`" do
     context "from `reload: true`" do
       let_it_be(:user, reload: true) { create(:user) }
+      let_it_be(:users) { [user] }
 
       it "skips leakage detection" do
-        expect { user.update(name: "Other Name") }
+        expect { user.update!(name: "Other Name") }
           .not_to raise_error
       end
     end
 
     context "from `refind: true`" do
       let_it_be(:user, refind: true) { create(:user) }
+      let_it_be(:users) { [user] }
 
       it "skips leakage detection" do
-        expect { user.update(name: "Other Name") }
+        expect { user.update!(name: "Other Name") }
+          .not_to raise_error
+      end
+    end
+
+    context "from `freeze: false`" do
+      let_it_be(:user, freeze: false) { create(:user) }
+      let_it_be(:users) { [user] }
+
+      it "skips leakage detection" do
+        expect { user.update!(name: "Other Name") }
+          .not_to raise_error
+      end
+    end
+
+    context "from metadata", let_it_be_defrost: true do
+      let_it_be(:user) { create(:user) }
+      let_it_be(:users) { [user] }
+
+      it "skips leakage detection" do
+        expect { user.update!(name: "Other Name") }
           .not_to raise_error
       end
     end

--- a/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_prof/recipes/rspec/let_it_be"
+
+# `order: defined` is to make sure the example that modifies the state
+# is being run first, and the "victim" example runs afterwards.
+RSpec.describe "Modification detection on associations", order: :defined do
+  include TestProf::FactoryBot::Syntax::Methods
+
+  # If you add `freeze: false` `let_it_be` option, state will leak
+  # and the unsuspecting second example will fail.
+  let_it_be(:user) { create(:user, name: "Original Name") }
+
+  it "detects the leak" do
+    expect { user.update!(name: "John Doe") }
+      .to raise_error(FrozenError, /can't modify frozen Hash/)
+  end
+
+  it { expect(user.name).to eq("Original Name") }
+
+  context "with an array of values" do
+    let_it_be(:users) { create_list(:user, 2) }
+
+    it "detects the leak" do
+      expect { users.first.update!(name: "John Doe") }
+        .to raise_error(FrozenError, /can't modify frozen Hash/)
+    end
+  end
+
+  describe "infers `freeze: false`" do
+    context "from `reload: true`" do
+      let_it_be(:user, reload: true) { create(:user) }
+
+      it "skips leakage detection" do
+        expect { user.update(name: "Other Name") }
+          .not_to raise_error
+      end
+    end
+
+    context "from `refind: true`" do
+      let_it_be(:user, refind: true) { create(:user) }
+
+      it "skips leakage detection" do
+        expect { user.update(name: "Other Name") }
+          .not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
@@ -87,4 +87,10 @@ RSpec.describe "Modification detection" do
       end
     end
   end
+
+  describe "combination of cross-referenced reloadable and freezable objects" do
+    # TODO: make sure stoplist works - smoke test, no specific expectation, just that there's no FrozenError
+    # TODO: make sure stoplist is reset
+    # TODO: make sure stoplist is not reset on each example/group, just the outermost one
+  end
 end

--- a/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
@@ -32,6 +32,26 @@ RSpec.describe "Modification detection", let_it_be_frost: true do
     it { expect(post.user.name).to eq("Original Name") }
   end
 
+  describe "no state leakage with transactional tests with `refind: true`", :transactional, order: :defined do
+    let_it_be(:post, refind: true) { create(:post, user: create(:user, name: "Original Name")) }
+
+    it "leaks" do
+      post.user.update!(name: "John Doe")
+    end
+
+    it { expect(post.user.name).to eq("Original Name") }
+  end
+
+  describe "no state leakage with transactional tests with `reload: true`", :transactional, order: :defined do
+    let_it_be(:post, reload: true) { create(:post, user: create(:user, name: "Original Name")) }
+
+    it "leaks" do
+      post.user.update!(name: "John Doe")
+    end
+
+    it { expect(post.user.name).to eq("Original Name") }
+  end
+
   context "with an array of values" do
     let_it_be(:users) { create_list(:user, 2) }
 

--- a/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
@@ -88,9 +88,25 @@ RSpec.describe "Modification detection", let_it_be_frost: true do
     end
   end
 
-  describe "combination of cross-referenced reloadable and freezable objects" do
-    # TODO: make sure stoplist works - smoke test, no specific expectation, just that there's no FrozenError
-    # TODO: make sure stoplist is reset
-    # TODO: make sure stoplist is not reset on each example/group, just the outermost one
+  describe "combination of cross-referenced freezable and non-freezable objects" do
+    describe "level one" do
+      let_it_be(:one, freeze: false) { ["one"] }
+
+      describe "level two" do
+        let_it_be(:two) { [one, ["two"]] }
+
+        describe "level three" do
+          let_it_be(:three, freeze: false) { [one, two, "three"] }
+
+          it "only freezes what's necessary" do
+            expect { one.push(1) }.not_to raise_error
+            expect { two.push(2) }.to raise_error(/can't modify frozen/)
+            expect { two.first.push(2) }.not_to raise_error
+            expect { two.last.push(2) }.to raise_error(/can't modify frozen/)
+            expect { three.push(3) }.not_to raise_error
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modification_detection.rb
@@ -2,7 +2,7 @@
 
 require "test_prof/recipes/rspec/let_it_be"
 
-RSpec.describe "Modification detection" do
+RSpec.describe "Modification detection", let_it_be_frost: true do
   include TestProf::FactoryBot::Syntax::Methods
 
   # `order: defined` is to make sure the example that modifies the state
@@ -77,7 +77,7 @@ RSpec.describe "Modification detection" do
       end
     end
 
-    context "from metadata", let_it_be_defrost: true do
+    context "from metadata", let_it_be_frost: false do
       let_it_be(:user) { create(:user) }
       let_it_be(:users) { [user] }
 

--- a/spec/integrations/fixtures/rspec/let_it_be_modification_detection_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modification_detection_fixture.rb
@@ -41,8 +41,8 @@ RSpec.describe "Modification detection", :transactional, let_it_be_frost: true d
     it { expect(post.user.name).to eq("Original Name") }
   end
 
-  describe "no state leakage with transactional tests with `refind: true` and `freeze: false`", order: :defined do
-    let_it_be(:post, refind: true, freeze: false) { create(:post, user: create(:user, name: "Original Name")) }
+  describe "no state leakage with transactional tests with `refind: true`", order: :defined do
+    let_it_be(:post, refind: true) { create(:post, user: create(:user, name: "Original Name")) }
 
     it "leaks" do
       post.user.update!(name: "John Doe")
@@ -51,8 +51,8 @@ RSpec.describe "Modification detection", :transactional, let_it_be_frost: true d
     it { expect(post.user.name).to eq("Original Name") }
   end
 
-  describe "no state leakage with transactional tests with `reload: true` and `freeze: false`", order: :defined do
-    let_it_be(:post, reload: true, freeze: false) { create(:post, user: create(:user, name: "Original Name")) }
+  describe "no state leakage with transactional tests with `reload: true`", order: :defined do
+    let_it_be(:post, reload: true) { create(:post, user: create(:user, name: "Original Name")) }
 
     it "leaks" do
       post.user.update!(name: "John Doe")
@@ -105,7 +105,7 @@ RSpec.describe "Modification detection", :transactional, let_it_be_frost: true d
         describe "level three" do
           let_it_be(:three, freeze: false) { [one, two, "three"] }
 
-          it "only freezes what's necessary" do
+          it "only freezes what's necessary", :aggregate_failures do
             expect { one.push(1) }.not_to raise_error
             expect { two.push(2) }.to raise_error(/can't modify frozen/i)
             expect { two.first.push(2) }.not_to raise_error

--- a/spec/integrations/fixtures/rspec/let_it_be_modification_detection_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modification_detection_fixture.rb
@@ -18,7 +18,7 @@ RSpec.describe "Modification detection", let_it_be_frost: true do
 
     it "detects the leak" do
       expect { user.update!(name: "John Doe") }
-        .to raise_error(/can't modify frozen/)
+        .to raise_error(/[Cc]an't modify frozen/)
     end
 
     it { expect(user.name).to eq("Original Name") }
@@ -29,7 +29,7 @@ RSpec.describe "Modification detection", let_it_be_frost: true do
 
     it "detects the leak" do
       expect { post.user.update!(name: "John Doe") }
-        .to raise_error(/can't modify frozen/)
+        .to raise_error(/[Cc]an't modify frozen/)
     end
 
     it { expect(post.user.name).to eq("Original Name") }
@@ -60,12 +60,12 @@ RSpec.describe "Modification detection", let_it_be_frost: true do
 
     it "detects the leak in an array item" do
       expect { users.first.update!(name: "John Doe") }
-        .to raise_error(/can't modify frozen/)
+        .to raise_error(/[Cc]an't modify frozen/)
     end
 
     it "detects the leak in the array itself" do
       expect { users << "yet another user" }
-        .to raise_error(/can't modify frozen/)
+        .to raise_error(/[Cc]an't modify frozen/)
     end
   end
 
@@ -123,9 +123,9 @@ RSpec.describe "Modification detection", let_it_be_frost: true do
 
           it "only freezes what's necessary" do
             expect { one.push(1) }.not_to raise_error
-            expect { two.push(2) }.to raise_error(/can't modify frozen/)
+            expect { two.push(2) }.to raise_error(/[Cc]an't modify frozen/)
             expect { two.first.push(2) }.not_to raise_error
-            expect { two.last.push(2) }.to raise_error(/can't modify frozen/)
+            expect { two.last.push(2) }.to raise_error(/[Cc]an't modify frozen/)
             expect { three.push(3) }.not_to raise_error
           end
         end

--- a/spec/integrations/fixtures/rspec/let_it_be_modification_detection_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modification_detection_fixture.rb
@@ -5,7 +5,7 @@ require_relative "../../../support/transactional_context"
 
 require "test_prof/recipes/rspec/let_it_be"
 
-RSpec.describe "Modification detection", let_it_be_frost: true do
+RSpec.describe "Modification detection", :transactional, let_it_be_frost: true do
   include TestProf::FactoryBot::Syntax::Methods
 
   # `order: defined` is to make sure the example that modifies the state
@@ -35,7 +35,7 @@ RSpec.describe "Modification detection", let_it_be_frost: true do
     it { expect(post.user.name).to eq("Original Name") }
   end
 
-  describe "no state leakage with transactional tests with `refind: true`", :transactional, order: :defined do
+  describe "no state leakage with transactional tests with `refind: true`", order: :defined do
     let_it_be(:post, refind: true) { create(:post, user: create(:user, name: "Original Name")) }
 
     it "leaks" do
@@ -45,7 +45,7 @@ RSpec.describe "Modification detection", let_it_be_frost: true do
     it { expect(post.user.name).to eq("Original Name") }
   end
 
-  describe "no state leakage with transactional tests with `reload: true`", :transactional, order: :defined do
+  describe "no state leakage with transactional tests with `reload: true`", order: :defined do
     let_it_be(:post, reload: true) { create(:post, user: create(:user, name: "Original Name")) }
 
     it "leaks" do

--- a/spec/integrations/fixtures/rspec/let_it_be_modification_detection_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modification_detection_fixture.rb
@@ -18,7 +18,7 @@ RSpec.describe "Modification detection", let_it_be_frost: true do
 
     it "detects the leak" do
       expect { user.update!(name: "John Doe") }
-        .to raise_error(FrozenError, /can't modify frozen/)
+        .to raise_error(/can't modify frozen/)
     end
 
     it { expect(user.name).to eq("Original Name") }
@@ -29,7 +29,7 @@ RSpec.describe "Modification detection", let_it_be_frost: true do
 
     it "detects the leak" do
       expect { post.user.update!(name: "John Doe") }
-        .to raise_error(FrozenError, /can't modify frozen/)
+        .to raise_error(/can't modify frozen/)
     end
 
     it { expect(post.user.name).to eq("Original Name") }
@@ -60,12 +60,12 @@ RSpec.describe "Modification detection", let_it_be_frost: true do
 
     it "detects the leak in an array item" do
       expect { users.first.update!(name: "John Doe") }
-        .to raise_error(FrozenError, /can't modify frozen/)
+        .to raise_error(/can't modify frozen/)
     end
 
     it "detects the leak in the array itself" do
       expect { users << "yet another user" }
-        .to raise_error(FrozenError, /can't modify frozen/)
+        .to raise_error(/can't modify frozen/)
     end
   end
 

--- a/spec/integrations/fixtures/rspec/let_it_be_modification_detection_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modification_detection_fixture.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative "../../../support/ar_models"
+require_relative "../../../support/transactional_context"
+
 require "test_prof/recipes/rspec/let_it_be"
 
 RSpec.describe "Modification detection", let_it_be_frost: true do

--- a/spec/integrations/fixtures/rspec/let_it_be_modifiers_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_modifiers_fixture.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require_relative "../../../support/ar_models"
+require_relative "../../../support/transactional_context"
+
+require "test_prof/recipes/rspec/let_it_be"
+
+RSpec.configure do |config|
+  config.include TestProf::FactoryBot::Syntax::Methods
+end
+
+TestProf::LetItBe.configure do |config|
+  config.default_modifiers[:refind] = true
+end
+
+RSpec.describe "Post", :transactional do
+  let_it_be(:post) { @post = create(:post) }
+
+  let(:user) { post.user }
+
+  it "validates name" do
+    user.name = ""
+    expect(user).not_to be_valid
+  end
+
+  it "is valid" do
+    expect(user).to be_valid
+  end
+
+  it "should refind" do
+    expect(@post.user).to eq(user)
+    expect(@post.user.object_id).not_to eq(user.object_id)
+  end
+
+  context "with modifier override", order: :defined do
+    let_it_be(:user, refind: false) { create(:user) }
+
+    it "validates name" do
+      user.name = ""
+      expect(user).not_to be_valid
+    end
+
+    it "is not valid" do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context "with modifier override via metadata", let_it_be_modifiers: {refind: false}, order: :defined do
+    let_it_be(:user) { @user = create(:user) }
+
+    it "validates name" do
+      user.name = ""
+      expect(user).not_to be_valid
+    end
+
+    it "is not valid" do
+      expect(user).not_to be_valid
+    end
+
+    context "with overrides", let_it_be_modifiers: {reload: true} do
+      let_it_be(:user, refind: false) { @user = create(:user) }
+      let_it_be(:user2, reload: false, refind: true) { @user2 = create(:user) }
+
+      it "validates name" do
+        user.name = ""
+        user2.name = ""
+
+        expect(user).not_to be_valid
+        expect(user2).not_to be_valid
+      end
+
+      it "is valid" do
+        expect(user).to be_valid
+        expect(user2).to be_valid
+      end
+
+      it "has object_id" do
+        expect(@user.object_id).to eq(user.object_id)
+        expect(@user2.object_id).not_to eq(user2.object_id)
+      end
+    end
+  end
+end

--- a/spec/integrations/let_it_be_spec.rb
+++ b/spec/integrations/let_it_be_spec.rb
@@ -7,6 +7,12 @@ describe "LetItBe" do
     expect(output).to include("0 failures")
   end
 
+  specify "default and metadata modifiers" do
+    output = run_rspec("let_it_be_modifiers")
+
+    expect(output).to include("0 failures")
+  end
+
   specify "it detects state leakages" do
     output = run_rspec("let_it_be_modification_detection")
 

--- a/spec/integrations/let_it_be_spec.rb
+++ b/spec/integrations/let_it_be_spec.rb
@@ -6,4 +6,10 @@ describe "LetItBe" do
 
     expect(output).to include("0 failures")
   end
+
+  specify "it detects state leakages" do
+    output = run_rspec("let_it_be_modification_detection")
+
+    expect(output).to include("0 failures")
+  end
 end

--- a/spec/integrations/sample_spec.rb
+++ b/spec/integrations/sample_spec.rb
@@ -51,7 +51,7 @@ describe "Tests Sampling" do
     specify "SAMPLE_GROUPS=2 with seed" do
       outputs = Array
         .new(10) { run_rspec("sample", env: {"SAMPLE_GROUPS" => "2"}, options: "--format=documentation --seed 42") }
-        .map { |output| output.gsub(/Finished in.*/, "") }
+        .map { |output| output.gsub(/Finished in.*/, "").gsub(/\s/m, "") }
 
       expect(outputs.uniq.size).to eq 1
     end

--- a/spec/integrations/sample_spec.rb
+++ b/spec/integrations/sample_spec.rb
@@ -53,7 +53,7 @@ describe "Tests Sampling" do
         .new(10) { run_rspec("sample", env: {"SAMPLE_GROUPS" => "2"}, options: "--format=documentation --seed 42") }
         .map { |output| output.gsub(/Finished in.*/, "").gsub(/\s/m, "") }
 
-      expect(outputs.uniq.size).to eq 1
+      expect(outputs.uniq.size).to eq(1), "Outputs must be equal:\n#{outputs.uniq.join("\n")}"
     end
   end
 
@@ -93,9 +93,9 @@ describe "Tests Sampling" do
     specify "SAMPLE_GROUPS=2 with seed" do
       outputs = Array
         .new(10) { run_minitest("sample", env: {"SAMPLE_GROUPS" => "2", "TESTOPTS" => "-v --seed 42"}) }
-        .map { |output| output.gsub(/Finished in.*/, "") }
+        .map { |output| output.gsub(/Finished in.*/, "").gsub(/\s/, "") }
 
-      expect(outputs.uniq.size).to eq 1
+      expect(outputs.uniq.size).to eq(1), "Outputs must be equal:\n#{outputs.uniq.join("\n")}"
     end
   end
 end

--- a/spec/support/ar_models.rb
+++ b/spec/support/ar_models.rb
@@ -63,7 +63,7 @@ TestProf::FactoryBot.define do
   end
 
   factory :post do
-    sequence(:text) { |n| "Post ##{n}}" }
+    sequence(:text) { |n| "Post ##{n}" }
     user
 
     trait :with_bad_user do


### PR DESCRIPTION
### Changes
- [x] `freeze: true` modifier (aka auto-magic state leakage detection, #178)
- [x] Default (global) `let_it_be` modifiers (`config.default_modifiers[:freeze] = true`)
- [x] Metadata-inferred modifiers (`context "some case", let_it_be_modifiers: {refind: true}`).

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
